### PR TITLE
スムーズスクロールのcssプロパティ削除

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -14012,14 +14012,6 @@ template {
   display: none;
 }
 
-/**
- * スムーズスクロールのスタイル
- * SPAのようにページ遷移ごとにスクロール位置の調整が必要な場合に微妙な挙動になるかも。
- */
-html {
-  scroll-behavior: smooth;
-}
-
 * {
   box-sizing: border-box;
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=1accba589ca31a0657cc",
-    "/css/app.css": "/css/app.css?id=16c1b712e36e3f93408a"
+    "/css/app.css": "/css/app.css?id=73297adeac4d0a7c2a99"
 }

--- a/src/resources/sass/foundation/_base.scss
+++ b/src/resources/sass/foundation/_base.scss
@@ -1,11 +1,3 @@
-/**
- * スムーズスクロールのスタイル
- * SPAのようにページ遷移ごとにスクロール位置の調整が必要な場合に微妙な挙動になるかも。
- */
-html {
-  scroll-behavior: smooth;
-}
-
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
### **作業内容**
htmlセレクタに指定した `scroll-behavior: smooth;`を削除