### PR TITLE
スクロールボタンの作成とインポート周り修正

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -2578,8 +2578,8 @@ import用ファイル
  * component
  */
 .scroll-top[data-v-10d75cdd] {
-  width: 3rem;
-  height: 3rem;
+  width: 100%;
+  height: 100%;
   padding: 0.5rem;
   background-color: #e56c2c;
   border-radius: 50%;
@@ -2588,9 +2588,19 @@ import用ファイル
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  transition: background-color 0.3s ease-out;
 }
 @media screen and (min-width: 1025px) {
+.scroll-top[data-v-10d75cdd] {
+    background-color: rgba(229, 108, 44, 0.7);
+    transition: background-color 0.3s ease-out, -webkit-animation 0.5s;
+    transition: background-color 0.3s ease-out, animation 0.5s;
+    transition: background-color 0.3s ease-out, animation 0.5s, -webkit-animation 0.5s;
+}
+}
+@media screen and (min-width: 1025px) {
+.scroll-top[data-v-10d75cdd]:hover {
+    background-color: #e56c2c;
+}
 .scroll-top:hover .scroll-top__icon[data-v-10d75cdd] {
     -webkit-animation: fadeoutTop-data-v-10d75cdd 1s linear infinite;
             animation: fadeoutTop-data-v-10d75cdd 1s linear infinite;
@@ -2599,6 +2609,17 @@ import用ファイル
 .scroll-top__icon[data-v-10d75cdd] {
   width: 0.75rem;
   color: #ffffff;
+}
+.scrollTop-enter-active[data-v-10d75cdd], .scrollTop-leave-active[data-v-10d75cdd] {
+  transition: transform 0.5s ease-out, opacity 0.3s;
+}
+.scrollTop-enter[data-v-10d75cdd], .scrollTop-leave-to[data-v-10d75cdd] {
+  opacity: 0;
+  transform: scale(0);
+}
+.scrollTop-enter-to[data-v-10d75cdd] {
+  opacity: 1;
+  transform: scale(1);
 }@charset "UTF-8";
 /*
 import用ファイル
@@ -2990,8 +3011,10 @@ import用ファイル
 }
 .home__scroll-top[data-v-63cd6604] {
   position: fixed;
-  bottom: 0.5rem;
-  right: 0.5rem;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
 }
 @media screen and (min-width: 1025px) {
 .about[data-v-63cd6604] {
@@ -3068,17 +3091,6 @@ import用ファイル
 .support__text[data-v-63cd6604] {
   width: 80%;
   margin: 0 auto;
-}
-.scrollTop-enter-active[data-v-63cd6604], .scrollTop-leave-active[data-v-63cd6604] {
-  transition: transform 0.5s ease-out, opacity 0.3s;
-}
-.scrollTop-enter[data-v-63cd6604], .scrollTop-leave-to[data-v-63cd6604] {
-  opacity: 0;
-  transform: scale(0);
-}
-.scrollTop-enter-to[data-v-63cd6604] {
-  opacity: 1;
-  transform: scale(1);
 }@charset "UTF-8";
 /*
 import用ファイル

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -3035,6 +3035,7 @@ import用ファイル
 }
 .home__scroll-top[data-v-63cd6604] {
   position: fixed;
+  z-index: 10;
   bottom: 1rem;
   right: 1rem;
   width: 3rem;
@@ -7950,6 +7951,14 @@ import用ファイル
 .club__photo[data-v-357d3955] {
   margin-top: 2.5rem;
 }
+.club__scroll-top[data-v-357d3955] {
+  position: fixed;
+  z-index: 10;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
+}
 .dormitory__slider[data-v-357d3955], .practice__slider[data-v-357d3955] {
   margin-top: 5rem;
 }
@@ -9536,6 +9545,14 @@ import用ファイル
   padding-bottom: 5rem;
   margin-bottom: 0;
 }
+.member__scroll-top[data-v-668c6779] {
+  position: fixed;
+  z-index: 10;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
+}
 .main-visual__icon[data-v-668c6779] {
   width: 80%;
   max-width: 20rem;
@@ -10308,6 +10325,14 @@ import用ファイル
     justify-content: flex-start;
     align-items: stretch;
 }
+}
+.hakumonkai__scroll-top[data-v-42f1fe89] {
+  position: fixed;
+  z-index: 10;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
 }
 .background-prlx[data-v-42f1fe89] {
   background-image: url("/image/group-photo2017-spring.jpg");
@@ -12647,6 +12672,14 @@ import用ファイル
 }
 .history__winner[data-v-301d0ec5] {
   margin: 0 auto;
+}
+.history__scroll-top[data-v-301d0ec5] {
+  position: fixed;
+  z-index: 10;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
 }
 .archive[data-v-301d0ec5] {
   display: flex;
@@ -16100,6 +16133,14 @@ import用ファイル
 .photo__gallery[data-v-46e3fba3] {
     margin-top: 0;
 }
+}
+.photo__scroll-top[data-v-46e3fba3] {
+  position: fixed;
+  z-index: 10;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3rem;
+  height: 3rem;
 }
 .ticket-group[data-v-46e3fba3] {
   display: flex;

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -3068,6 +3068,17 @@ import用ファイル
 .support__text[data-v-63cd6604] {
   width: 80%;
   margin: 0 auto;
+}
+.scrollTop-enter-active[data-v-63cd6604], .scrollTop-leave-active[data-v-63cd6604] {
+  transition: transform 0.5s ease-out, opacity 0.3s;
+}
+.scrollTop-enter[data-v-63cd6604], .scrollTop-leave-to[data-v-63cd6604] {
+  opacity: 0;
+  transform: scale(0);
+}
+.scrollTop-enter-to[data-v-63cd6604] {
+  opacity: 1;
+  transform: scale(1);
 }@charset "UTF-8";
 /*
 import用ファイル

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -2286,6 +2286,356 @@ import用ファイル
 /**
  * @keyframe を定義
  */
+@-webkit-keyframes iconSlide-data-v-10d75cdd {
+0% {
+    transform: translateX(0);
+}
+10% {
+    transform: translateX(10%);
+}
+20% {
+    transform: translateX(20%);
+}
+30% {
+    transform: translateX(30%);
+}
+40% {
+    transform: translateX(40%);
+}
+50% {
+    transform: translateX(50%);
+}
+60% {
+    transform: translateX(40%);
+}
+70% {
+    transform: translateX(30%);
+}
+80% {
+    transform: translateX(20%);
+}
+90% {
+    transform: translateX(10%);
+}
+100% {
+    transform: translateX(0);
+}
+}
+@keyframes iconSlide-data-v-10d75cdd {
+0% {
+    transform: translateX(0);
+}
+10% {
+    transform: translateX(10%);
+}
+20% {
+    transform: translateX(20%);
+}
+30% {
+    transform: translateX(30%);
+}
+40% {
+    transform: translateX(40%);
+}
+50% {
+    transform: translateX(50%);
+}
+60% {
+    transform: translateX(40%);
+}
+70% {
+    transform: translateX(30%);
+}
+80% {
+    transform: translateX(20%);
+}
+90% {
+    transform: translateX(10%);
+}
+100% {
+    transform: translateX(0);
+}
+}
+@-webkit-keyframes fadeoutDown-data-v-10d75cdd {
+0% {
+    transform: translateY(0);
+}
+10% {
+    opacity: 0.9;
+    transform: translateY(10%);
+}
+20% {
+    opacity: 0.8;
+    transform: translateY(20%);
+}
+30% {
+    opacity: 0.7;
+    transform: translateY(30%);
+}
+40% {
+    opacity: 0.6;
+    transform: translateY(40%);
+}
+50% {
+    opacity: 0.5;
+    transform: translateY(50%);
+}
+60% {
+    opacity: 0.4;
+    transform: translateY(60%);
+}
+70% {
+    opacity: 0.3;
+    transform: translateY(70%);
+}
+80% {
+    opacity: 0.2;
+    transform: translateY(80%);
+}
+90% {
+    opacity: 0.1;
+    transform: translateY(90%);
+}
+100% {
+    opacity: 0;
+    transform: translateY(100%);
+}
+}
+@keyframes fadeoutDown-data-v-10d75cdd {
+0% {
+    transform: translateY(0);
+}
+10% {
+    opacity: 0.9;
+    transform: translateY(10%);
+}
+20% {
+    opacity: 0.8;
+    transform: translateY(20%);
+}
+30% {
+    opacity: 0.7;
+    transform: translateY(30%);
+}
+40% {
+    opacity: 0.6;
+    transform: translateY(40%);
+}
+50% {
+    opacity: 0.5;
+    transform: translateY(50%);
+}
+60% {
+    opacity: 0.4;
+    transform: translateY(60%);
+}
+70% {
+    opacity: 0.3;
+    transform: translateY(70%);
+}
+80% {
+    opacity: 0.2;
+    transform: translateY(80%);
+}
+90% {
+    opacity: 0.1;
+    transform: translateY(90%);
+}
+100% {
+    opacity: 0;
+    transform: translateY(100%);
+}
+}
+@-webkit-keyframes fadeoutTop-data-v-10d75cdd {
+0% {
+    opacity: 1;
+    transform: translateY(0);
+}
+100% {
+    opacity: 0;
+    transform: translateY(-30%);
+}
+}
+@keyframes fadeoutTop-data-v-10d75cdd {
+0% {
+    opacity: 1;
+    transform: translateY(0);
+}
+100% {
+    opacity: 0;
+    transform: translateY(-30%);
+}
+}
+@-webkit-keyframes bound-data-v-10d75cdd {
+0% {
+    transform: translate(0%, -100%);
+}
+30% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+40% {
+    transform: translate(0%, -40%);
+}
+55% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+60% {
+    transform: translate(0%, -15%);
+}
+70% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+75% {
+    transform: translate(0%, -5%);
+}
+95% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+100% {
+    transform: scale(1, 1);
+}
+}
+@keyframes bound-data-v-10d75cdd {
+0% {
+    transform: translate(0%, -100%);
+}
+30% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+40% {
+    transform: translate(0%, -40%);
+}
+55% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+60% {
+    transform: translate(0%, -15%);
+}
+70% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+75% {
+    transform: translate(0%, -5%);
+}
+95% {
+    transform: translate(0%, 0%) scale(1.1, 1);
+}
+100% {
+    transform: scale(1, 1);
+}
+}
+@-webkit-keyframes rotation-data-v-10d75cdd {
+0% {
+    transform: translateX(-50rem) rotate(0deg);
+}
+100% {
+    transform: translateX(0) rotate(1455deg);
+}
+}
+@keyframes rotation-data-v-10d75cdd {
+0% {
+    transform: translateX(-50rem) rotate(0deg);
+}
+100% {
+    transform: translateX(0) rotate(1455deg);
+}
+}
+@-webkit-keyframes loading-data-v-10d75cdd {
+0% {
+    height: 0;
+}
+50% {
+    height: 80%;
+}
+100% {
+    height: 0;
+}
+}
+@keyframes loading-data-v-10d75cdd {
+0% {
+    height: 0;
+}
+50% {
+    height: 80%;
+}
+100% {
+    height: 0;
+}
+}
+/**
+ * common mixin (サイト内でどこでも使う可能性がある)
+ */
+/**
+ * gradation
+ */
+/**
+ * element
+ */
+/**
+ * 装飾用 mixin
+ */
+/**
+ * component
+ */
+.scroll-top[data-v-10d75cdd] {
+  width: 3rem;
+  height: 3rem;
+  padding: 0.5rem;
+  background-color: #e56c2c;
+  border-radius: 50%;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transition: background-color 0.3s ease-out;
+}
+@media screen and (min-width: 1025px) {
+.scroll-top:hover .scroll-top__icon[data-v-10d75cdd] {
+    -webkit-animation: fadeoutTop-data-v-10d75cdd 1s linear infinite;
+            animation: fadeoutTop-data-v-10d75cdd 1s linear infinite;
+}
+}
+.scroll-top__icon[data-v-10d75cdd] {
+  width: 0.75rem;
+  color: #ffffff;
+}@charset "UTF-8";
+/*
+import用ファイル
+グローバルに使用する変数やmixinをインポート
+*/
+/**
+ * サイトで使用するマップを定義します
+ */
+/**
+ * ベースとなるフォントサイズ = 16px
+ * modules.scssでremに変換して出力
+ */
+/**
+ * base pixel (8px)
+ * rem だとフォントサイズに影響するため、pixelで定義
+ */
+/**
+ * google map size
+ */
+/**
+ * アスペクト比（基準を100%と想定）
+ */
+/**
+ * radius
+ */
+/**
+ * サイト内で扱うsass関数とキーフレームを定義するファイル。
+ * _variables.scssで定義した変数を呼び出しやすい形に変換
+ */
+/**
+ * font size
+ * @param 指定したいピクセル数を入力
+ * @return 単位をremに変換し出力
+ */
+/**
+ * @keyframe を定義
+ */
 @-webkit-keyframes iconSlide-data-v-63cd6604 {
 0% {
     transform: translateX(0);
@@ -2637,6 +2987,11 @@ import用ファイル
 .home__background[data-v-63cd6604] {
     height: auto;
 }
+}
+.home__scroll-top[data-v-63cd6604] {
+  position: fixed;
+  bottom: 0.5rem;
+  right: 0.5rem;
 }
 @media screen and (min-width: 1025px) {
 .about[data-v-63cd6604] {
@@ -18843,31 +19198,6 @@ import用ファイル
 .footer__address[data-v-060e08fe] {
   position: relative;
   margin-bottom: 0;
-}
-.footer__scroll-top[data-v-060e08fe] {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  width: 3rem;
-  height: 3rem;
-  padding: 0.5rem;
-  border: 1px solid #091e2f;
-  border-radius: 50%;
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-  transition: background-color 0.3s ease-out;
-}
-@media screen and (min-width: 1025px) {
-.footer__scroll-top:hover .footer__scroll-icon[data-v-060e08fe] {
-    -webkit-animation: fadeoutTop-data-v-060e08fe 1s linear infinite;
-            animation: fadeoutTop-data-v-060e08fe 1s linear infinite;
-}
-}
-.footer__scroll-icon[data-v-060e08fe] {
-  width: 0.75rem;
 }
 .footer__copyright[data-v-060e08fe] {
   font-size: 0.625rem;

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -324,6 +324,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .main-visual[data-v-3ff6fe5a] {
@@ -672,6 +675,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -1033,6 +1039,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -1403,6 +1412,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -1841,6 +1853,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .link__btn[data-v-63d84db2], .link[data-v-63d84db2] {
@@ -2217,6 +2232,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .text-box {
@@ -2573,6 +2591,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -2944,6 +2965,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -3417,6 +3441,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .google-map__map[data-v-161a410d] {
@@ -3767,6 +3794,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -4166,6 +4196,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .image-slider__container[data-v-6cd5e234] {
@@ -4536,6 +4569,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .main-visual-slider[data-v-30380e08] {
@@ -4892,6 +4928,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -5301,6 +5340,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .caption-bar-image[data-v-7fa4fe02] {
@@ -5666,6 +5708,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -6036,6 +6081,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -6415,6 +6463,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .grade-tag__content {
@@ -6762,6 +6813,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -7154,6 +7208,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .slider[data-v-53189f00] {
@@ -7498,6 +7555,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -7867,6 +7927,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -8373,6 +8436,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -8973,6 +9039,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .user-ticket {
@@ -9455,6 +9524,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .member__players[data-v-668c6779] {
@@ -9851,6 +9923,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .tile-table {
@@ -10207,6 +10282,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -10587,6 +10665,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -10990,6 +11071,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -11398,6 +11482,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .history-box[data-v-600734dc] {
@@ -11778,6 +11865,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .icon-table {
@@ -12131,6 +12221,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -12534,6 +12627,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -12942,6 +13038,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .view-all {
@@ -13331,6 +13430,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .pull-down-table {
@@ -13693,6 +13795,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -14210,6 +14315,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .images__filter[data-v-7ec9af9b] {
@@ -14638,6 +14746,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .sns-tag {
@@ -14998,6 +15109,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -15421,6 +15535,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -15971,6 +16088,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .photo__gallery[data-v-46e3fba3] {
@@ -16327,6 +16447,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -16835,6 +16958,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -17721,6 +17847,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .accordion-link {
@@ -18129,6 +18258,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component
@@ -18689,6 +18821,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .header__navbar[data-v-6832e7cf] {
@@ -19191,6 +19326,9 @@ import用ファイル
  * 装飾用 mixin
  */
 /**
+ * page
+ */
+/**
  * component
  */
 .footer[data-v-060e08fe] {
@@ -19576,6 +19714,9 @@ import用ファイル
  */
 /**
  * 装飾用 mixin
+ */
+/**
+ * page
  */
 /**
  * component

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=a03871867f6431654f51",
+    "/js/app.js": "/js/app.js?id=7c4e427272098af05339",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=cabe168953d64f740843",
+    "/js/app.js": "/js/app.js?id=a03871867f6431654f51",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=7f52635491633e5ffd14",
-    "/css/app.css": "/css/app.css?id=585afb2c0ffff731fdd1"
+    "/js/app.js": "/js/app.js?id=e7fa078dc8583b853bcf",
+    "/css/app.css": "/css/app.css?id=1e8e42ef5c9f704e3dca"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/js/app.js": "/js/app.js?id=e7fa078dc8583b853bcf",
-    "/css/app.css": "/css/app.css?id=1e8e42ef5c9f704e3dca"
+    "/css/app.css": "/css/app.css?id=8995221a07cf4119104e"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=e5cf6db08e96bb2a5aee",
+    "/js/app.js": "/js/app.js?id=07021fff596a9c782333",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=e7fa078dc8583b853bcf",
-    "/css/app.css": "/css/app.css?id=8995221a07cf4119104e"
+    "/js/app.js": "/js/app.js?id=6ab59e100c4ae27082c1",
+    "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=07021fff596a9c782333",
+    "/js/app.js": "/js/app.js?id=f318613b3f1dd49540b4",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=7c4e427272098af05339",
+    "/js/app.js": "/js/app.js?id=e5cf6db08e96bb2a5aee",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=f318613b3f1dd49540b4",
+    "/js/app.js": "/js/app.js?id=694e39b082b3f9b8f4ce",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=6ab59e100c4ae27082c1",
+    "/js/app.js": "/js/app.js?id=cabe168953d64f740843",
     "/css/app.css": "/css/app.css?id=1efd58294de20cc73319"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=458972408c0a5dd6f524",
-    "/css/app.css": "/css/app.css?id=a2457fab251aebab7edb"
+    "/js/app.js": "/js/app.js?id=87552858293bfa127f1a",
+    "/css/app.css": "/css/app.css?id=81b3b2bc9860864f320b"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=87552858293bfa127f1a",
-    "/css/app.css": "/css/app.css?id=81b3b2bc9860864f320b"
+    "/js/app.js": "/js/app.js?id=7f52635491633e5ffd14",
+    "/css/app.css": "/css/app.css?id=585afb2c0ffff731fdd1"
 }

--- a/src/resources/js/components/contents/ArrangeImagesComponent.vue
+++ b/src/resources/js/components/contents/ArrangeImagesComponent.vue
@@ -17,6 +17,7 @@ export default {
       default: null
     }
   },
+
   computed: {
     imagesArraySlice() {
       return this.imagesData.slice(0, 10);  // 配列の要素をを10個にスライス

--- a/src/resources/js/components/contents/HistoryBoxComponent.vue
+++ b/src/resources/js/components/contents/HistoryBoxComponent.vue
@@ -1,12 +1,12 @@
 <template>
 <div class="history-box">
   <div class="history-box__tag-record" @click="openModal">
-    <record-tag-component/>
+    <record-tag/>
   </div>
 
   <!-- タグ押下時のモーダル -->
   <div class="history-box__modal" v-if="showModal">
-    <modal-component @close="closeModal">
+    <modal @close="closeModal">
       <template v-slot:content>
         <div class="record-modal">
           <div class="record-modal__box" v-for="(item, n) in data.Records" :key="n">
@@ -15,7 +15,7 @@
           </div>
         </div>
       </template>
-    </modal-component>
+    </modal>
   </div>
 
   <div class="history-box__title">
@@ -24,7 +24,7 @@
   </div>
 
   <div class="history-box__tag-date">
-    <tag-component color="outline-orange" :content="data.Term"/>
+    <tag color="outline-orange" :content="data.Term"/>
   </div>
 
   <div class="history-box__text-container">
@@ -36,9 +36,9 @@
 
 <script>
 // component import
-import TagComponent from '../modules/tag/TagComponent';
-import RecordTagComponent from '../modules/tag/RecordTagComponent';
-import ModalComponent from '../modules/modal/ModalComponent.vue';
+import Tag from '../modules/tag/TagComponent';
+import RecordTag from '../modules/tag/RecordTagComponent';
+import Modal from '../modules/modal/ModalComponent.vue';
 import TableComponent from '../modules/table/TableComponent.vue';
 
 // data import
@@ -46,9 +46,9 @@ import Data from '../../config/data.json';
 
 export default {
   components: {
-    TagComponent,
-    RecordTagComponent,
-    ModalComponent,
+    Tag,
+    RecordTag,
+    Modal,
     TableComponent,
   },
 

--- a/src/resources/js/components/contents/ImagesComponent.vue
+++ b/src/resources/js/components/contents/ImagesComponent.vue
@@ -5,7 +5,7 @@
   <div class="images__filter">
     <span class="images__filter-name">{{ messages.FunctionName.Filter }}</span>
 
-    <pull-down-table-component :titles="filter.year" :menus="years" @select="select = $event"/>
+    <pull-down-table :titles="filter.year" :menus="years" @select="select = $event"/>
   </div>
 
   <!-- 写真 -->
@@ -18,7 +18,7 @@
   </div>
 
   <!-- 写真クリック後のモーダル -->
-  <image-modal-component
+  <image-modal
     v-if="showModal"
     @close="closeModal"
     :selectIndex="selectImageIndex"
@@ -26,7 +26,7 @@
 
   <!-- もっと見るボタン -->
   <div class="images__button" v-if="buttonShow">
-    <view-all-button-component :clickEvent="viewMore"/>
+    <view-all-button :clickEvent="viewMore"/>
   </div>
 
 </div>
@@ -34,15 +34,15 @@
 
 <script>
 // component import
-import ViewAllButtonComponent from '../modules/button/ViewAllButtonComponent';
-import PullDownTableComponent from '../modules/table/PullDownTableComponent';
-import ImageModalComponent from '../modules/modal/ImageModalComponent';
+import ViewAllButton from '../modules/button/ViewAllButtonComponent';
+import PullDownTable from '../modules/table/PullDownTableComponent';
+import ImageModal from '../modules/modal/ImageModalComponent';
 
 export default {
   components: {
-    ViewAllButtonComponent,
-    PullDownTableComponent,
-    ImageModalComponent,
+    ViewAllButton,
+    PullDownTable,
+    ImageModal,
   },
 
   data() {

--- a/src/resources/js/components/contents/NewsComponent.vue
+++ b/src/resources/js/components/contents/NewsComponent.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="news">
 
-  <contents-title-component :title="messages.SectionTitles.News.Main" :subTitle="messages.SectionTitles.News.Sub"/>
+  <contents-title :title="messages.SectionTitles.News.Main" :subTitle="messages.SectionTitles.News.Sub"/>
 
   <div class="news__loading" v-if="loading">
     <!-- <transition-group name="load" tag="div"> -->
@@ -31,7 +31,7 @@
       <span class="err__text">{{ messages.Error.Api.News }}</span>
 
       <div class="err__btn">
-        <primary-button-component :btn="messages.Button.NewsRequest" @clickEvent="getResponse"/>
+        <primary-button :btn="messages.Button.NewsRequest" @clickEvent="getResponse"/>
       </div>
     </div>
   </div>
@@ -41,16 +41,16 @@
 
 <script>
 // components import
-import ContentsTitleComponent from '../modules/ContentsTitleComponent';
-import PrimaryButtonComponent from '../modules/button/PrimaryButtonComponent.vue';
+import ContentsTitle from '../modules/ContentsTitleComponent';
+import PrimaryButton from '../modules/button/PrimaryButtonComponent.vue';
 
 // Library import
 import axios from 'axios';
 
 export default {
   components: {
-    ContentsTitleComponent,
-    PrimaryButtonComponent,
+    ContentsTitle,
+    PrimaryButton,
   },
 
   data() {

--- a/src/resources/js/components/layouts/FooterComponent.vue
+++ b/src/resources/js/components/layouts/FooterComponent.vue
@@ -2,7 +2,7 @@
 <footer class="footer">
 
   <section class="footer__contact">
-    <contents-title-component
+    <contents-title
     :title="messages.SectionTitles.Contact.Main"
     :subTitle="messages.SectionTitles.Contact.Sub"/>
 
@@ -11,14 +11,14 @@
     </div>
 
     <div class="footer__contact-btn">
-      <link-button-component :link="messages.Links.ToContact"/>
+      <link-button :link="messages.Links.ToContact"/>
     </div>
   </section>
 
   <section class="footer__accordion">
     <ul class="footer__list">
       <li class="footer__list-item" v-for="(link, n) in links" :key="n">
-        <accordion-link-component :item="link" color="darkblue"/>
+        <accordion-link :item="link" color="darkblue"/>
       </li>
     </ul>
   </section>
@@ -47,9 +47,9 @@
 
 <script>
 // component import
-import AccordionLinkComponent from '../modules/accordion/AccordionLinkComponent.vue';
-import LinkButtonComponent from '../modules/button/LinkButtonComponent';
-import ContentsTitleComponent from '../modules/ContentsTitleComponent.vue';
+import AccordionLink from '../modules/accordion/AccordionLinkComponent.vue';
+import LinkButton from '../modules/button/LinkButtonComponent';
+import ContentsTitle from '../modules/ContentsTitleComponent.vue';
 
 // data import
 import Data from '../../config/data.json';
@@ -57,9 +57,9 @@ import Config from '../../config/config.json';
 
 export default {
   components: {
-    ContentsTitleComponent,
-    LinkButtonComponent,
-    AccordionLinkComponent,
+    ContentsTitle,
+    LinkButton,
+    AccordionLink,
   },
 
   data() {

--- a/src/resources/js/components/layouts/FooterComponent.vue
+++ b/src/resources/js/components/layouts/FooterComponent.vue
@@ -37,10 +37,6 @@
 
       <span class="address__item">{{ messages.Information.MailAddress }}</span>
     </address>
-
-    <!-- <div class="footer__scroll-top" id="scrollTarget" @click="scrollTop()" :class="{ 'footer__scroll-top--animation': scrollAnimation }">
-      <svg-vue class="footer__scroll-icon" icon="angle-up-double"/>
-    </div> -->
   </section>
 
   <section class="footer__copyright">
@@ -82,12 +78,6 @@ export default {
        * @type {Number}
        */
       telephoneNum: '',
-
-      /**
-       * スクロールボタンのアニメーションを制御するフラグ
-       * @type {Boolean}
-       */
-      scrollAnimation: false
     }
   },
 
@@ -118,26 +108,6 @@ export default {
   },
 
   methods: {
-    scrollTop() {
-      // cssアニメーションを行うため、ボタンにクラスをつける
-      this.scrollAnimation = true;
-
-      // css アニメーションが完了次第実行 css fadeout -> .3s
-      setTimeout(() => {
-        /**
-         * ページ最上部までスクロール
-         * ! (safari,IE)非対応
-         */
-        window.scrollTo({
-          top: 0,
-          behavior: 'smooth'
-        })
-
-        // アニメーションフラグをデフォルトに戻す
-        this.scrollAnimation = false;
-      }, 500);
-    },
-
     /**
      * オブジェクトから配列に変換する処理
      * @param { Object }
@@ -185,30 +155,6 @@ export default {
   &__address {
     position: relative;
     margin-bottom: 0;
-  }
-
-  &__scroll-top {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: interval(6);
-    height: interval(6);
-    padding: interval(1);
-    border: 1px solid color(darkblue);
-    border-radius: radius(circle);
-    @include flex(row nowrap, center, center);
-    cursor: pointer;
-    transition: background-color .3s ease-out;
-
-    @include hover {
-      .footer__scroll-icon {
-        animation: fadeoutTop 1s linear infinite;
-      }
-    }
-  }
-
-  &__scroll-icon {
-    width: interval(1.5);
   }
 
   &__copyright {

--- a/src/resources/js/components/layouts/HeaderComponent.vue
+++ b/src/resources/js/components/layouts/HeaderComponent.vue
@@ -20,7 +20,7 @@
   </div>
 
   <!-- グローバルナビ（モーダル） -->
-  <nav-modal-component v-if="navShow" @close="closeModal"/>
+  <nav-modal v-if="navShow" @close="closeModal"/>
 
 </header>
 </template>
@@ -31,14 +31,14 @@ import Data from '../../config/data.json';
 import Config from '../../config/config.json';
 
 // component import
-import NavModalComponent from '../modules/modal/NavModalComponent.vue';
+import NavModal from '../modules/modal/NavModalComponent.vue';
 
 // mixin
 import TwitterAccount from '../../config/api/TwitterAccount';
 
 export default {
   components: {
-    NavModalComponent,
+    NavModal,
   },
 
   mixins: [TwitterAccount],

--- a/src/resources/js/components/layouts/HeaderComponent.vue
+++ b/src/resources/js/components/layouts/HeaderComponent.vue
@@ -1,6 +1,6 @@
 <template>
 <header class="header">
-  <div class="header__navbar" :class="{ 'header__navbar--hide': headerShow }" ref="header">
+  <div class="header__navbar" :class="{ 'header__navbar--hide': headerShow }">
     <router-link to="/" class="header__navbar-link">
       <div class="header__title">
         <span class="header__title-main">{{ messages.Header.MainTitle }}</span>
@@ -80,25 +80,21 @@ export default {
     this.getTwitterAccount();
   },
 
-  mounted() {
-    // ヘッダーの高さ取得
-    this.headerHeight = this.$refs.header.offsetHeight;
-  },
-
   watch: {
     /**
      * [スクロールに応じてヘッダーの表示を制御する]
      */
-    scrollAmount() {
-      let pos = this.scrollAmount;             // スクロール現在地
-      const headerHeight = this.headerHeight;  // ヘッダーの高さ
+    scrollY() {
+      let pos = this.scrollY;             // スクロール現在地
       let lastpos = this.lastScrollPosition;   // 最後のスクロール位置
 
-      // ヘッダーの高さ分スクロール かつ 上スクロールした際にクラスを付与
-      (pos > headerHeight && pos > lastpos) ? this.headerShow = true : this.headerShow = false;
+      /**
+       * 60pxスクロール かつ 上スクロールした際にクラスを付与
+       */
+      (pos > 60 && pos > lastpos) ? this.headerShow = true : this.headerShow = false;
 
       // 最後のスクロール位置を更新
-      this.lastScrollPosition = this.scrollAmount;
+      this.lastScrollPosition = this.scrollY;
     }
   },
 

--- a/src/resources/js/components/modules/CaptionBarImageComponent.vue
+++ b/src/resources/js/components/modules/CaptionBarImageComponent.vue
@@ -27,6 +27,7 @@ export default {
       default: 0,
     },
   },
+
   computed: {
     radiusClass() {
       return (this.radius) ? `c-image__image-radius` : null;

--- a/src/resources/js/components/modules/ContentsTitleComponent.vue
+++ b/src/resources/js/components/modules/ContentsTitleComponent.vue
@@ -8,11 +8,6 @@
 
 <script>
 export default {
-  data() {
-    return {
-
-    }
-  },
   props: {
     color: {
       type: String,
@@ -27,6 +22,7 @@ export default {
       default: 'タイトル',
     },
   },
+
   computed: {
     colorChange() {
       return (this.color) ? `contents-title-${this.color}` : null;

--- a/src/resources/js/components/modules/TextBoxComponent.vue
+++ b/src/resources/js/components/modules/TextBoxComponent.vue
@@ -1,26 +1,26 @@
 <template>
 <div class="text-box">
   <div class="text-box__title">
-    <contents-title-component :title="content.title.Main" :subTitle="content.title.Sub"/>
+    <contents-title :title="content.title.Main" :subTitle="content.title.Sub"/>
   </div>
   <div class="text-box__text">
     <p class="nl2br" v-text="content.text"></p>
   </div>
   <div class="text-box__button">
-    <link-button-component :link="content.button"/>
+    <link-button :link="content.button"/>
   </div>
 </div>
 </template>
 
 <script>
 // components import
-import ContentsTitleComponent from './ContentsTitleComponent';
-import LinkButtonComponent from './button/LinkButtonComponent';
+import ContentsTitle from './ContentsTitleComponent';
+import LinkButton from './button/LinkButtonComponent';
 
 export default {
   components: {
-    ContentsTitleComponent,
-    LinkButtonComponent,
+    ContentsTitle,
+    LinkButton,
   },
 
   data() {

--- a/src/resources/js/components/modules/button/ScrollTopButtonComponent.vue
+++ b/src/resources/js/components/modules/button/ScrollTopButtonComponent.vue
@@ -6,12 +6,6 @@
 
 <script>
 export default {
-  data() {
-    return {
-
-    }
-  },
-
   methods: {
     scrollTop() {
       window.scrollTo({

--- a/src/resources/js/components/modules/button/ScrollTopButtonComponent.vue
+++ b/src/resources/js/components/modules/button/ScrollTopButtonComponent.vue
@@ -1,11 +1,23 @@
 <template>
-  <button class="scroll-top" id="scrollTarget" @click="scrollTop()">
-    <svg-vue class="scroll-top__icon" icon="angle-up-double"/>
-  </button>
+  <transition name="scrollTop">
+    <button class="scroll-top" @click="scrollTop()" v-if="showBtn">
+      <svg-vue class="scroll-top__icon" icon="angle-up-double"/>
+    </button>
+  </transition>
 </template>
 
 <script>
 export default {
+  data() {
+    return {
+      /**
+       * スクロールボタンの表示制御
+       * @type { Boolean }
+       */
+      showBtn: false,
+    }
+  },
+
   methods: {
     scrollTop() {
       window.scrollTo({
@@ -14,21 +26,33 @@ export default {
       })
     },
   },
+
+  watch: {
+    scrollY() {
+      (this.scrollY > 1000) ? this.showBtn = true : this.showBtn = false;
+    }
+  },
 }
 </script>
 
 <style lang="scss" scoped>
 .scroll-top {
-  width: interval(6);
-  height: interval(6);
+  width: 100%;
+  height: 100%;
   padding: interval(1);
   background-color: color(orange);
   border-radius: radius(circle);
   @include flex(row nowrap, center, center);
   cursor: pointer;
-  transition: background-color .3s ease-out;
+
+  @include mq(md) {
+    background-color: rgba($color: color(orange), $alpha: .7);
+    transition: background-color .3s ease-out, animation .5s;
+  }
 
   @include hover {
+    background-color: color(orange);
+
     .scroll-top__icon {
       animation: fadeoutTop 1s linear infinite;
     }
@@ -37,6 +61,23 @@ export default {
   &__icon {
     width: interval(1.5);
     color: color(white);
+  }
+}
+
+// アニメーション
+.scrollTop {
+  &-enter-active, &-leave-active {
+    transition: transform .5s ease-out, opacity .3s;
+  }
+
+  &-enter, &-leave-to {
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  &-enter-to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 </style>

--- a/src/resources/js/components/modules/button/ScrollTopButtonComponent.vue
+++ b/src/resources/js/components/modules/button/ScrollTopButtonComponent.vue
@@ -1,0 +1,48 @@
+<template>
+  <button class="scroll-top" id="scrollTarget" @click="scrollTop()">
+    <svg-vue class="scroll-top__icon" icon="angle-up-double"/>
+  </button>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+
+    }
+  },
+
+  methods: {
+    scrollTop() {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      })
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.scroll-top {
+  width: interval(6);
+  height: interval(6);
+  padding: interval(1);
+  background-color: color(orange);
+  border-radius: radius(circle);
+  @include flex(row nowrap, center, center);
+  cursor: pointer;
+  transition: background-color .3s ease-out;
+
+  @include hover {
+    .scroll-top__icon {
+      animation: fadeoutTop 1s linear infinite;
+    }
+  }
+
+  &__icon {
+    width: interval(1.5);
+    color: color(white);
+  }
+}
+</style>

--- a/src/resources/js/components/modules/card/PlayerCardComponent.vue
+++ b/src/resources/js/components/modules/card/PlayerCardComponent.vue
@@ -13,10 +13,10 @@
     <div class="player-card__tag-group">
 
       <div class="player-card__tag">
-        <position-tag-component :position="player.position"/>
+        <position-tag :position="player.position"/>
       </div>
       <div class="player-card__tag">
-        <grade-tag-component v-if="player.grade" :grade="player.grade"/>
+        <grade-tag v-if="player.grade" :grade="player.grade"/>
       </div>
     </div>
 
@@ -33,16 +33,15 @@
 
 <script>
 // component import
-import TagComponent from '../tag/TagComponent';
-import PositionTagComponent from '../tag/PositionTagComponent';
-import GradeTagComponent from '../tag/GradeTagComponent';
+import PositionTag from '../tag/PositionTagComponent';
+import GradeTag from '../tag/GradeTagComponent';
 
 export default {
   components: {
-    TagComponent,
-    PositionTagComponent,
-    GradeTagComponent,
+    PositionTag,
+    GradeTag,
   },
+
   props: {
     player: {
       type: Object,

--- a/src/resources/js/components/modules/modal/ModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ModalComponent.vue
@@ -16,8 +16,6 @@
 
 <script>
 export default {
-  props: {
-  }
 
 }
 </script>

--- a/src/resources/js/components/modules/modal/NavModalComponent.vue
+++ b/src/resources/js/components/modules/modal/NavModalComponent.vue
@@ -19,7 +19,7 @@
         <nav class="nav-modal__main">
           <div class="nav-modal__accordion">
             <div class="nav-modal__accordion-item" v-for="(link, n) in links" :key="n">
-              <accordion-link-component :item="link" @navClose="$emit('close')"/>
+              <accordion-link :item="link" @navClose="$emit('close')"/>
             </div>
           </div>
 
@@ -56,7 +56,7 @@
 
 <script>
 // component import
-import AccordionLinkComponent from '../accordion/AccordionLinkComponent';
+import AccordionLink from '../accordion/AccordionLinkComponent';
 
 // data
 import Config from '../../../config/config.json';
@@ -66,7 +66,7 @@ import TwitterAccount from '../../../config/api/TwitterAccount';
 
 export default {
   components: {
-    AccordionLinkComponent,
+    AccordionLink,
   },
 
   mixins: [TwitterAccount],

--- a/src/resources/js/components/modules/modal/ProviderTicketModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ProviderTicketModalComponent.vue
@@ -44,17 +44,11 @@
 
 <script>
 // component import
-import TagComponent from '../tag/TagComponent.vue';
-import PositionTagComponent from '../tag/PositionTagComponent.vue';
-import GradeTagComponent from '../tag/GradeTagComponent.vue';
-import TableComponent from '../table/TableComponent.vue';
+
 
 export default {
   components: {
-    TagComponent,
-    PositionTagComponent,
-    GradeTagComponent,
-    TableComponent,
+
   },
 
   data() {

--- a/src/resources/js/components/modules/modal/TicketModalComponent.vue
+++ b/src/resources/js/components/modules/modal/TicketModalComponent.vue
@@ -28,13 +28,13 @@
 
                   <div class="ticket-modal__tag-group">
                     <div class="ticket-modal__tag" v-if="item.post.club">
-                      <tag-component :content="item.post.club" :responsive="true"/>
+                      <tag :content="item.post.club" :responsive="true"/>
                     </div>
                     <div class="ticket-modal__tag" v-if="item.position">
-                      <position-tag-component :position="item.position" :responsive="true"/>
+                      <position-tag :position="item.position" :responsive="true"/>
                     </div>
                     <div class="ticket-modal__tag" v-if="item.grade">
-                      <grade-tag-component :grade="item.grade" :responsive="true"/>
+                      <grade-tag :grade="item.grade" :responsive="true"/>
                     </div>
                   </div>
                 </div>
@@ -64,16 +64,16 @@
 
 <script>
 // component import
-import TagComponent from '../tag/TagComponent.vue';
-import PositionTagComponent from '../tag/PositionTagComponent.vue';
-import GradeTagComponent from '../tag/GradeTagComponent.vue';
+import Tag from '../tag/TagComponent.vue';
+import PositionTag from '../tag/PositionTagComponent.vue';
+import GradeTag from '../tag/GradeTagComponent.vue';
 import TableComponent from '../table/TableComponent.vue';
 
 export default {
   components: {
-    TagComponent,
-    PositionTagComponent,
-    GradeTagComponent,
+    Tag,
+    PositionTag,
+    GradeTag,
     TableComponent,
   },
 

--- a/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
@@ -16,6 +16,7 @@ export default {
   props: {
     images: Array,
   },
+
   computed: {
     params() {
       return {

--- a/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
@@ -2,13 +2,13 @@
   <div class="slider">
     <swiper ref="contentsImageSwiper" :options="params">
       <swiper-slide v-for="(player, n) in players" :key="n">
-        <player-card-component :player="player">
+        <player-card :player="player">
           <template v-slot:addCardContents="player" v-if="player.category === activeAlumniNum">
             <div class="alumni__record">
               <span class="alumni__record-text">{{ player.player.record }}</span>
             </div>
           </template>
-        </player-card-component>
+        </player-card>
       </swiper-slide>
 
       <!-- <div class="swiper-pagination" slot="pagination"></div> -->
@@ -20,11 +20,11 @@
 
 <script>
 // components import
-import PlayerCardComponent from '../card/PlayerCardComponent';
+import PlayerCard from '../card/PlayerCardComponent';
 
 export default {
   components: {
-    PlayerCardComponent,
+    PlayerCard,
   },
 
   props: {

--- a/src/resources/js/components/modules/slider/contentsImageSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/contentsImageSliderComponent.vue
@@ -29,6 +29,7 @@ export default {
   props: {
     images: Array,
   },
+
   computed: {
     params() {
       return {

--- a/src/resources/js/components/modules/table/TileTableComponent.vue
+++ b/src/resources/js/components/modules/table/TileTableComponent.vue
@@ -22,6 +22,7 @@ export default {
       type: Array,
       default: null
     },
+
     tableItemHeading: {
       type: Array,
       default: null

--- a/src/resources/js/components/modules/tag/GradeTagComponent.vue
+++ b/src/resources/js/components/modules/tag/GradeTagComponent.vue
@@ -1,20 +1,20 @@
 <template>
 <div class="grade-tag">
-  <tag-component>
+  <tag>
     <span class="grade-tag__content" :class="[sizing, {'grade-tag__content--responsive': responsive}]">
       {{ grade }}年生
     </span>
-  </tag-component>
+  </tag>
 </div>
 </template>
 
 <script>
 // component import
-import TagComponent from './TagComponent'
+import Tag from './TagComponent'
 
 export default {
   components: {
-    TagComponent
+    Tag
   },
 
   props: {

--- a/src/resources/js/components/modules/tag/PositionTagComponent.vue
+++ b/src/resources/js/components/modules/tag/PositionTagComponent.vue
@@ -1,16 +1,16 @@
 <template>
 <div class="position-tag">
-  <tag-component :color="positionColor" :content="position" :size="size" :responsive="responsive"/>
+  <tag :color="positionColor" :content="position" :size="size" :responsive="responsive"/>
 </div>
 </template>
 
 <script>
 // component import
-import TagComponent from './TagComponent'
+import Tag from './TagComponent'
 
 export default {
   components: {
-    TagComponent
+    Tag
   },
 
   props: {

--- a/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
@@ -12,9 +12,9 @@
     <!-- SNSタグは 2つ まで -->
     <div class="provider-ticket-tag-group">
       <!-- twitter -->
-      <sns-tag-component sns="twitter" content="Twitter"/>
+      <sns-tag sns="twitter" content="Twitter"/>
       <!-- instagram -->
-      <sns-tag-component sns="instagram" content="Instagram"/>
+      <sns-tag sns="instagram" content="Instagram"/>
     </div>
   </div>
 
@@ -27,11 +27,11 @@
 
 <script>
 // component import
-import SnsTagComponent from '../tag/SnsTagComponent';
+import SnsTag from '../tag/SnsTagComponent';
 
 export default {
   components: {
-    SnsTagComponent,
+    SnsTag,
   },
 
   props: {

--- a/src/resources/js/components/modules/ticket/UserTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/UserTicketComponent.vue
@@ -13,17 +13,17 @@
     <!-- ユーザーカテゴリーが選手の場合 -->
     <div v-if="userObj.category === 1" class="user-ticket-tag-group">
       <div class="user-ticket-tag">
-        <position-tag-component :position="userObj.position"/>
+        <position-tag :position="userObj.position"/>
       </div>
       <div class="user-ticket-tag">
-        <grade-tag-component :grade="userObj.grade"/>
+        <grade-tag :grade="userObj.grade"/>
       </div>
     </div>
 
     <!-- 選手ではない場合（スタッフ）は役職を出す -->
     <div v-else class="user-ticket-tag-group">
       <div class="user-ticket-tag">
-        <tag-component :content="userObj.post.club"/>
+        <tag :content="userObj.post.club"/>
       </div>
     </div>
   </div>
@@ -37,15 +37,15 @@
 
 <script>
 // component import
-import TagComponent from '../tag/TagComponent';
-import PositionTagComponent from '../tag/PositionTagComponent';
-import GradeTagComponent from '../tag/GradeTagComponent';
+import Tag from '../tag/TagComponent';
+import PositionTag from '../tag/PositionTagComponent';
+import GradeTag from '../tag/GradeTagComponent';
 
 export default {
   components: {
-    TagComponent,
-    PositionTagComponent,
-    GradeTagComponent,
+    Tag,
+    PositionTag,
+    GradeTag,
   },
 
   props: {

--- a/src/resources/js/config/global.js
+++ b/src/resources/js/config/global.js
@@ -25,7 +25,7 @@ export default {
        * [現在のスクロール量]
        * @type { Number }
        */
-      scrollAmount: null,
+      scrollY: null,
 
       /**
      * [ユーザーカテゴリー情報]
@@ -57,7 +57,7 @@ export default {
      * [スクロール量をリアルタイムで取得]
      * @type { function }
      */
-    this.scrollAmount = window.scrollY;
+    this.scrollY = window.scrollY;
     window.addEventListener('scroll', this.getScroll);
   },
 
@@ -74,7 +74,7 @@ export default {
      * https://gray-code.com/javascript/unset-event-listener/
     */
     getScroll() {
-      this.scrollAmount = window.scrollY;
+      this.scrollY = window.scrollY;
     },
 
     /**

--- a/src/resources/js/views/Club.vue
+++ b/src/resources/js/views/Club.vue
@@ -2,16 +2,16 @@
 <div class="club">
 
   <div class="club__mainVisualSlider">
-    <main-visual-slider-component :images="mainVisualImages"/>
+    <main-visual-slider :images="mainVisualImages"/>
   </div>
 
   <div class="background-darkblue">
     <section class="club__concept">
-      <contents-title-component :title="messages.SectionTitles.Concept.Main" :subTitle="messages.SectionTitles.Concept.Sub" color="white"/>
+      <contents-title :title="messages.SectionTitles.Concept.Main" :subTitle="messages.SectionTitles.Concept.Sub" color="white"/>
 
       <div class="concept__card-group">
         <div class="concept__card" v-for="(concept, n) in concepts" :key="n">
-          <concept-card-component :concept="concept"/>
+          <concept-card :concept="concept"/>
         </div>
       </div>
 
@@ -19,25 +19,25 @@
   </div>
 
   <section class="club__practice">
-    <contents-title-component :title="messages.SectionTitles.Practice.Main" :subTitle="messages.SectionTitles.Practice.Sub"/>
+    <contents-title :title="messages.SectionTitles.Practice.Main" :subTitle="messages.SectionTitles.Practice.Sub"/>
 
     <div class="practice__table">
       <table-component :tableItems="practiceInformations"/>
     </div>
 
     <div class="practice__map">
-      <google-map-component/>
+      <google-map/>
     </div>
 
     <!-- PCデバイス幅 以下 -->
     <div class="practice__slider" v-if="windowWidth < breakpointPc">
-      <contents-image-slider-component :images="courtImages"/>
+      <contents-image-slider :images="courtImages"/>
     </div>
 
     <!-- PCデバイス幅 -->
     <div class="practice__image-group" v-if="windowWidth >= breakpointPc">
       <div class="practice__image" v-for="(image, n) in courtImages" :key="n">
-        <caption-bar-image-component :imageUrl="`/image/${image.path}`" :alt="image.name" :barCaption="image.caption"/>
+        <caption-bar-image :imageUrl="`/image/${image.path}`" :alt="image.name" :barCaption="image.caption"/>
       </div>
     </div>
 
@@ -51,7 +51,7 @@
   </section>
 
   <section class="club__dormitory">
-    <contents-title-component :title="messages.SectionTitles.Dormitory.Main" :subTitle="messages.SectionTitles.Dormitory.Sub"/>
+    <contents-title :title="messages.SectionTitles.Dormitory.Main" :subTitle="messages.SectionTitles.Dormitory.Sub"/>
 
     <div class="dormitory__lead">
       <p class="nl2br" v-text="messages.Club.Dormitory.LeadText"/>
@@ -59,19 +59,19 @@
 
     <div class="dormitory__ticket-group">
       <div class="dormitory__ticket" v-for="(dormitoryInformation, n) in dormitoryInformations" :key="n">
-        <dormitory-ticket-component :dormitoryData="dormitoryInformation"/>
+        <dormitory-ticket :dormitoryData="dormitoryInformation"/>
       </div>
     </div>
 
     <!-- PCデバイス幅 以下 -->
     <div class="dormitory__slider" v-if="windowWidth < breakpointPc">
-      <contents-image-slider-component :images="dormitoryImages"/>
+      <contents-image-slider :images="dormitoryImages"/>
     </div>
 
     <!-- PCデバイス幅 -->
     <div class="dormitory__image-group" v-if="windowWidth >= breakpointPc">
       <div class="dormitory__image" v-for="(image, n) in dormitoryImages" :key="n">
-        <caption-bar-image-component :imageUrl="`/image/${image.path}`" :alt="image.name" :capacityNum="image.capacity"/>
+        <caption-bar-image :imageUrl="`/image/${image.path}`" :alt="image.name" :capacityNum="image.capacity"/>
       </div>
     </div>
 
@@ -79,9 +79,9 @@
 
   <div class="background-darkblue">
     <section class="club__member">
-      <contents-title-component :title="messages.SectionTitles.Member.Main" :subTitle="messages.SectionTitles.Member.Sub" color="white"/>
+      <contents-title :title="messages.SectionTitles.Member.Main" :subTitle="messages.SectionTitles.Member.Sub" color="white"/>
 
-      <player-slider-component :players="players"/>
+      <player-slider :players="players"/>
 
       <div class="member__number">
         <h3 class="member__number-title">{{ messages.ContentsTitles.Numbers }}</h3>
@@ -91,19 +91,19 @@
         </div>
 
         <div class="member__button">
-          <link-button-component :link="messages.Links.Member"/>
+          <link-button :link="messages.Links.Member"/>
         </div>
       </div>
     </section>
   </div>
 
   <section class="club__photo">
-    <contents-title-component :title="messages.SectionTitles.Photo.Main" :subTitle="messages.SectionTitles.Photo.Sub"/>
+    <contents-title :title="messages.SectionTitles.Photo.Main" :subTitle="messages.SectionTitles.Photo.Sub"/>
 
-    <arrange-images-component :imagesData="imagesData"/>
+    <arrange-images :imagesData="imagesData"/>
 
     <div class="photo__button">
-      <link-button-component :link="messages.Links.Photo"/>
+      <link-button :link="messages.Links.Photo"/>
     </div>
   </section>
 
@@ -118,32 +118,32 @@
 import Data from '../config/data.json';
 
 // component import
-import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
-import GoogleMapComponent from '../components/modules/GoogleMapComponent';
-import conceptCardComponent from '../components/modules/card/conceptCardComponent';
-import ContentsImageSliderComponent from '../components/modules/slider/contentsImageSliderComponent';
-import MainVisualSliderComponent from '../components/modules/slider/MainVisualSliderComponent';
+import ContentsTitle from '../components/modules/ContentsTitleComponent';
+import GoogleMap from '../components/modules/GoogleMapComponent';
+import conceptCard from '../components/modules/card/conceptCardComponent';
+import ContentsImageSlider from '../components/modules/slider/contentsImageSliderComponent';
+import MainVisualSlider from '../components/modules/slider/MainVisualSliderComponent';
 import TableComponent from '../components/modules/table/TableComponent';
-import CaptionBarImageComponent from '../components/modules/CaptionBarImageComponent';
-import DormitoryTicketComponent from '../components/modules/ticket/DormitoryTicketComponent';
-import PlayerSliderComponent from '../components/modules/slider/PlayerSliderComponent';
-import LinkButtonComponent from '../components/modules/button/LinkButtonComponent';
-import ArrangeImagesComponent from '../components/contents/ArrangeImagesComponent';
+import CaptionBarImage from '../components/modules/CaptionBarImageComponent';
+import DormitoryTicket from '../components/modules/ticket/DormitoryTicketComponent';
+import PlayerSlider from '../components/modules/slider/PlayerSliderComponent';
+import LinkButton from '../components/modules/button/LinkButtonComponent';
+import ArrangeImages from '../components/contents/ArrangeImagesComponent';
 import scrollTopButton from '../components/modules/button/ScrollTopButtonComponent'
 
 export default {
   components: {
-    ContentsTitleComponent,
-    conceptCardComponent,
-    MainVisualSliderComponent,
+    ContentsTitle,
+    conceptCard,
+    MainVisualSlider,
     TableComponent,
-    GoogleMapComponent,
-    ContentsImageSliderComponent,
-    CaptionBarImageComponent,
-    DormitoryTicketComponent,
-    PlayerSliderComponent,
-    LinkButtonComponent,
-    ArrangeImagesComponent,
+    GoogleMap,
+    ContentsImageSlider,
+    CaptionBarImage,
+    DormitoryTicket,
+    PlayerSlider,
+    LinkButton,
+    ArrangeImages,
     scrollTopButton,
   },
   data() {

--- a/src/resources/js/views/Club.vue
+++ b/src/resources/js/views/Club.vue
@@ -106,12 +106,18 @@
       <link-button-component :link="messages.Links.Photo"/>
     </div>
   </section>
+
+  <div class="club__scroll-top">
+    <scroll-top-button/>
+  </div>
 </div>
 </template>
 
 <script>
-// component import
+// data
 import Data from '../config/data.json';
+
+// component import
 import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
 import GoogleMapComponent from '../components/modules/GoogleMapComponent';
 import conceptCardComponent from '../components/modules/card/conceptCardComponent';
@@ -123,6 +129,7 @@ import DormitoryTicketComponent from '../components/modules/ticket/DormitoryTick
 import PlayerSliderComponent from '../components/modules/slider/PlayerSliderComponent';
 import LinkButtonComponent from '../components/modules/button/LinkButtonComponent';
 import ArrangeImagesComponent from '../components/contents/ArrangeImagesComponent';
+import scrollTopButton from '../components/modules/button/ScrollTopButtonComponent'
 
 export default {
   components: {
@@ -137,6 +144,7 @@ export default {
     PlayerSliderComponent,
     LinkButtonComponent,
     ArrangeImagesComponent,
+    scrollTopButton,
   },
   data() {
     return {
@@ -328,6 +336,10 @@ const imageApiResponse = [
 
   &__photo {
     margin-top: interval(5);
+  }
+
+  &__scroll-top {
+    @include scroll-top();
   }
 }
 

--- a/src/resources/js/views/Hakumonkai.vue
+++ b/src/resources/js/views/Hakumonkai.vue
@@ -41,6 +41,10 @@
       <link-button-component :link="messages.Links.ToContact"/>
     </div>
   </section>
+
+  <div class="hakumonkai__scroll-top">
+    <scroll-top-button/>
+  </div>
 </div>
 </template>
 
@@ -54,6 +58,7 @@ import PlayerSliderComponent from '../components/modules/slider/PlayerSliderComp
 
 // data import
 import Data from '../config/data.json';
+import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
@@ -62,6 +67,7 @@ export default {
     PlayerCardComponent,
     LinkButtonComponent,
     PlayerSliderComponent,
+    ScrollTopButton,
   },
   data() {
     return {
@@ -105,6 +111,10 @@ export default {
     @include mq(sm) {
       @include flex(row nowrap, flex-start, stretch);
     }
+  }
+
+  &__scroll-top {
+    @include scroll-top();
   }
 }
 

--- a/src/resources/js/views/Hakumonkai.vue
+++ b/src/resources/js/views/Hakumonkai.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="hakumonkai">
   <section class="hakumonkai__header">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Hakumonkai.Main"
       :subTitle="messages.SectionTitles.Hakumonkai.Sub"/>
 
@@ -13,23 +13,23 @@
   <div class="background-prlx" v-prlx.background="{ speed: 0.3 }"/>
 
   <section class="hakumonkai__officer">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Officer.Main"
       :subTitle="messages.SectionTitles.Officer.Sub"/>
 
-    <tile-table-component :tableItemHeading="tableHeading" :tableItems="officer"/>
+    <tile-table :tableItemHeading="tableHeading" :tableItems="officer"/>
   </section>
 
   <section class="hakumonkai__active">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.ActiveAlumni.Main"
       :subTitle="messages.SectionTitles.ActiveAlumni.Sub"/>
 
-    <player-slider-component :players="activeAlumni"/>
+    <player-slider :players="activeAlumni"/>
   </section>
 
   <section class="hakumonkai__message">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Message.Main"
       :subTitle="messages.SectionTitles.Message.Sub"/>
 
@@ -38,7 +38,7 @@
     </div>
 
     <div class="message__button">
-      <link-button-component :link="messages.Links.ToContact"/>
+      <link-button :link="messages.Links.ToContact"/>
     </div>
   </section>
 
@@ -50,23 +50,23 @@
 
 <script>
 // components import
-import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
-import TileTableComponent from '../components/modules/table/TileTableComponent';
-import PlayerCardComponent from '../components/modules/card/PlayerCardComponent';
-import LinkButtonComponent from '../components/modules/button/LinkButtonComponent';
-import PlayerSliderComponent from '../components/modules/slider/PlayerSliderComponent.vue';
+import ContentsTitle from '../components/modules/ContentsTitleComponent';
+import TileTable from '../components/modules/table/TileTableComponent';
+import PlayerCard from '../components/modules/card/PlayerCardComponent';
+import LinkButton from '../components/modules/button/LinkButtonComponent';
+import PlayerSlider from '../components/modules/slider/PlayerSliderComponent';
+import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 // data import
 import Data from '../config/data.json';
-import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
-    ContentsTitleComponent,
-    TileTableComponent,
-    PlayerCardComponent,
-    LinkButtonComponent,
-    PlayerSliderComponent,
+    ContentsTitle,
+    TileTable,
+    PlayerCard,
+    LinkButton,
+    PlayerSlider,
     ScrollTopButton,
   },
   data() {

--- a/src/resources/js/views/History.vue
+++ b/src/resources/js/views/History.vue
@@ -2,7 +2,7 @@
 <div class="history">
 
   <section class="history__archive">
-    <contents-title-component :title="messages.SectionTitles.History.Main" :subTitle="messages.SectionTitles.History.Sub"/>
+    <contents-title :title="messages.SectionTitles.History.Main" :subTitle="messages.SectionTitles.History.Sub"/>
 
     <div class="archive" ref="archive">
 
@@ -19,21 +19,21 @@
         <!-- 大正の歴史 -->
         <div class="archive__wrap" ref="taisho">
           <div class="archive__content">
-            <history-box-component :data="data.Taisho"/>
+            <history-box :data="data.Taisho"/>
           </div>
         </div>
 
         <!-- 昭和の歴史 -->
         <div class="archive__wrap" ref="showa">
           <div class="archive__content" v-for="(showaHistory, i) in showa" :key="`first-${i}`">
-            <history-box-component :data="showaHistory"/>
+            <history-box :data="showaHistory"/>
           </div>
         </div>
 
         <!-- 平成の歴史 (今後コンテンツが増える可能性を考慮し、配列ループで表示) -->
         <div class="archive__wrap" ref="heisei">
           <div class="archive__content" v-for="(heiseiHistory, i) in heisei" :key="`second-${i}`">
-            <history-box-component :data="heiseiHistory"/>
+            <history-box :data="heiseiHistory"/>
           </div>
         </div>
 
@@ -42,21 +42,21 @@
   </section>
 
   <section class="history__trophies">
-    <contents-title-component :title="messages.SectionTitles.PrimaryTitles.Main" :subTitle="messages.SectionTitles.PrimaryTitles.Sub"/>
+    <contents-title :title="messages.SectionTitles.PrimaryTitles.Main" :subTitle="messages.SectionTitles.PrimaryTitles.Sub"/>
 
-    <icon-table-component :tableItems="trophies"/>
+    <icon-table :tableItems="trophies"/>
   </section>
 
   <div class="background-darkblue">
     <section class="history__winner">
-      <contents-title-component
+      <contents-title
         :title="messages.SectionTitles.Champions.Main"
         :subTitle="messages.SectionTitles.Champions.Sub"
         color="white"/>
 
       <div class="winner__card-group">
         <div class="winner__card" v-for="(champion, n) in champions" :key="n" ref="championCard">
-          <champions-card-component :cardElement="champion"/>
+          <champions-card :cardElement="champion"/>
         </div>
         <!-- カード配置を左揃えにするため、空の要素を追加 -->
         <div
@@ -77,20 +77,22 @@
 </template>
 
 <script>
-// import components
+// data
 import Data from '../config/data.json';
-import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
-import HistoryBoxComponent from '../components/contents/HistoryBoxComponent';
-import IconTableComponent from '../components/modules/table/IconTableComponent';
-import ChampionsCardComponent from '../components/modules/card/ChampionsCardComponent';
+
+// import components
+import ContentsTitle from '../components/modules/ContentsTitleComponent';
+import HistoryBox from '../components/contents/HistoryBoxComponent';
+import IconTable from '../components/modules/table/IconTableComponent';
+import ChampionsCard from '../components/modules/card/ChampionsCardComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
-    ContentsTitleComponent,
-    HistoryBoxComponent,
-    IconTableComponent,
-    ChampionsCardComponent,
+    ContentsTitle,
+    HistoryBox,
+    IconTable,
+    ChampionsCard,
     ScrollTopButton,
   },
   data() {

--- a/src/resources/js/views/History.vue
+++ b/src/resources/js/views/History.vue
@@ -193,7 +193,7 @@ export default {
       let marginBottom = this.archiveMarginBottom;
       let taishoHeight = this.elementsHeight.taisho + marginBottom;  // 大正の沿革ボックスの高さを代入
       let showaHeight  = taishoHeight + this.elementsHeight.showa + marginBottom;  // 昭和の沿革ボックスの高さを代入
-      let scroll = this.scrollAmount;  // スクロール量
+      let scroll = this.scrollY;  // スクロール量
       let age = this.ageWard;  // タグのテキスト
 
       if (scroll < taishoHeight) {
@@ -214,13 +214,13 @@ export default {
      * @return { Number }  沿革セクションの高さからタグの高さを引いた数値が返る
      */
     scrollLimit() {
-      let scroll = this.scrollAmount;  // スクロール量
+      let scroll = this.scrollY;  // スクロール量
       let archiveHeight = this.elementsHeight.archive;  // 沿革セクション全体の高さ
       let tag = this.elementsHeight.ageTag;  // スクロールタグの高さ
 
-      if (scroll > archiveHeight) this.scrollAmount = archiveHeight - tag;
+      if (scroll > archiveHeight) this.scrollY = archiveHeight - tag;
 
-      return this.scrollAmount;
+      return this.scrollY;
     }
   },
 

--- a/src/resources/js/views/History.vue
+++ b/src/resources/js/views/History.vue
@@ -69,6 +69,10 @@
     </section>
   </div>
 
+  <div class="history__scroll-top">
+    <scroll-top-button/>
+  </div>
+
 </div>
 </template>
 
@@ -79,6 +83,7 @@ import ContentsTitleComponent from '../components/modules/ContentsTitleComponent
 import HistoryBoxComponent from '../components/contents/HistoryBoxComponent';
 import IconTableComponent from '../components/modules/table/IconTableComponent';
 import ChampionsCardComponent from '../components/modules/card/ChampionsCardComponent';
+import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
@@ -86,6 +91,7 @@ export default {
     HistoryBoxComponent,
     IconTableComponent,
     ChampionsCardComponent,
+    ScrollTopButton,
   },
   data() {
     return {
@@ -266,6 +272,10 @@ export default {
 
   &__winner {
     margin: 0 auto;
+  }
+
+  &__scroll-top {
+    @include scroll-top();
   }
 }
 

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -33,6 +33,9 @@
       </section>
     </div>
 
+    <div class="home__scroll-top" v-if="showBtn">
+      <scroll-top-button-component/>
+    </div>
   </div>
 </template>
 
@@ -43,6 +46,7 @@ import MainVisualComponent from '../components/contents/MainVisualComponent';
 import NewsComponent from '../components/contents/NewsComponent';
 import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
 import TextBoxComponent from '../components/modules/TextBoxComponent';
+import ScrollTopButtonComponent from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
@@ -50,18 +54,30 @@ export default {
     NewsComponent,
     ContentsTitleComponent,
     TextBoxComponent,
+    ScrollTopButtonComponent,
   },
 
   data() {
     return {
       data: Data,
       aboutItems: [],
+
+      /**
+       * スクロールボタンの表示制御
+       */
+      showBtn: true,
     }
   },
 
   beforeMount() {
     // アバウトセクションを生成するデータを挿入。
     this.$data.data.HomeAbout.forEach(element => this.aboutItems.push(element));
+  },
+
+  methods: {
+    buttonToggle() {
+      // this.showBtn
+    }
   },
 }
 </script>
@@ -118,6 +134,12 @@ export default {
     @include mq(sm) {
       height: auto;
     }
+  }
+
+  &__scroll-top {
+    position: fixed;
+    bottom: interval(1);
+    right: interval(1);
   }
 }
 

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="home">
     <div class="home__main-visual">
-      <main-visual-component/>
+      <main-visual/>
     </div>
 
     <section class="home__news">
-      <news-component/>
+      <news/>
     </section>
 
     <section class="home__about">
@@ -15,14 +15,14 @@
         </figure>
 
         <div class="about__lead">
-          <text-box-component :contentProps="aboutItem"/>
+          <text-box :contentProps="aboutItem"/>
         </div>
       </div>
     </section>
 
     <div class="home__background">
       <section class="home__support">
-        <contents-title-component
+        <contents-title
           :title="messages.SectionTitles.Support.Main"
           :subTitle="messages.SectionTitles.Support.Sub"
           color="white"/>
@@ -41,20 +41,22 @@
 </template>
 
 <script>
-// component import
+// data
 import Data from '../config/data.json';
-import MainVisualComponent from '../components/contents/MainVisualComponent';
-import NewsComponent from '../components/contents/NewsComponent';
-import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
-import TextBoxComponent from '../components/modules/TextBoxComponent';
+
+// component import
+import MainVisual from '../components/contents/MainVisualComponent';
+import News from '../components/contents/NewsComponent';
+import ContentsTitle from '../components/modules/ContentsTitleComponent';
+import TextBox from '../components/modules/TextBoxComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
-    MainVisualComponent,
-    NewsComponent,
-    ContentsTitleComponent,
-    TextBoxComponent,
+    MainVisual,
+    News,
+    ContentsTitle,
+    TextBox,
     ScrollTopButton,
   },
 

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -33,9 +33,12 @@
       </section>
     </div>
 
-    <div class="home__scroll-top" v-if="showBtn">
-      <scroll-top-button-component/>
-    </div>
+    <transition name="scrollTop">
+      <div class="home__scroll-top" v-if="showBtn">
+        <scroll-top-button-component/>
+      </div>
+    </transition>
+
   </div>
 </template>
 
@@ -60,12 +63,17 @@ export default {
   data() {
     return {
       data: Data,
+
+      /**
+       * アバウトセクションを生成するデータ
+       */
       aboutItems: [],
 
       /**
        * スクロールボタンの表示制御
+       * @type { Boolean }
        */
-      showBtn: true,
+      showBtn: false,
     }
   },
 
@@ -74,9 +82,9 @@ export default {
     this.$data.data.HomeAbout.forEach(element => this.aboutItems.push(element));
   },
 
-  methods: {
-    buttonToggle() {
-      // this.showBtn
+  watch: {
+    scrollY() {
+      (this.scrollY > 1000) ? this.showBtn = true : this.showBtn = false;
     }
   },
 }
@@ -205,6 +213,23 @@ export default {
   &__text {
     width: 80%;
     margin: 0 auto;
+  }
+}
+
+// アニメーション
+.scrollTop {
+  &-enter-active, &-leave-active {
+    transition: transform .5s ease-out, opacity .3s;
+  }
+
+  &-enter, &-leave-to {
+    opacity: 0;
+    transform: scale(0);
+  }
+
+  &-enter-to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 </style>

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -33,11 +33,9 @@
       </section>
     </div>
 
-    <transition name="scrollTop">
-      <div class="home__scroll-top" v-if="showBtn">
-        <scroll-top-button-component/>
-      </div>
-    </transition>
+    <div class="home__scroll-top">
+      <scroll-top-button-component/>
+    </div>
 
   </div>
 </template>
@@ -68,24 +66,12 @@ export default {
        * アバウトセクションを生成するデータ
        */
       aboutItems: [],
-
-      /**
-       * スクロールボタンの表示制御
-       * @type { Boolean }
-       */
-      showBtn: false,
     }
   },
 
   beforeMount() {
     // アバウトセクションを生成するデータを挿入。
     this.$data.data.HomeAbout.forEach(element => this.aboutItems.push(element));
-  },
-
-  watch: {
-    scrollY() {
-      (this.scrollY > 1000) ? this.showBtn = true : this.showBtn = false;
-    }
   },
 }
 </script>
@@ -146,8 +132,10 @@ export default {
 
   &__scroll-top {
     position: fixed;
-    bottom: interval(1);
-    right: interval(1);
+    bottom: interval(2);
+    right: interval(2);
+    width: interval(6);
+    height: interval(6);
   }
 }
 
@@ -213,23 +201,6 @@ export default {
   &__text {
     width: 80%;
     margin: 0 auto;
-  }
-}
-
-// アニメーション
-.scrollTop {
-  &-enter-active, &-leave-active {
-    transition: transform .5s ease-out, opacity .3s;
-  }
-
-  &-enter, &-leave-to {
-    opacity: 0;
-    transform: scale(0);
-  }
-
-  &-enter-to {
-    opacity: 1;
-    transform: scale(1);
   }
 }
 </style>

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -131,11 +131,7 @@ export default {
   }
 
   &__scroll-top {
-    position: fixed;
-    bottom: interval(2);
-    right: interval(2);
-    width: interval(6);
-    height: interval(6);
+    @include scroll-button();
   }
 }
 

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -34,7 +34,7 @@
     </div>
 
     <div class="home__scroll-top">
-      <scroll-top-button-component/>
+      <scroll-top-button/>
     </div>
 
   </div>
@@ -47,7 +47,7 @@ import MainVisualComponent from '../components/contents/MainVisualComponent';
 import NewsComponent from '../components/contents/NewsComponent';
 import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
 import TextBoxComponent from '../components/modules/TextBoxComponent';
-import ScrollTopButtonComponent from '../components/modules/button/ScrollTopButtonComponent';
+import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
@@ -55,7 +55,7 @@ export default {
     NewsComponent,
     ContentsTitleComponent,
     TextBoxComponent,
-    ScrollTopButtonComponent,
+    ScrollTopButton,
   },
 
   data() {
@@ -131,7 +131,7 @@ export default {
   }
 
   &__scroll-top {
-    @include scroll-button();
+    @include scroll-top();
   }
 }
 

--- a/src/resources/js/views/Member.vue
+++ b/src/resources/js/views/Member.vue
@@ -1,16 +1,16 @@
 <template>
 <div class="member">
   <div class="member__main-visual">
-    <main-visual-component>
+    <main-visual>
       <template v-slot:inner>
         <svg-vue class="main-visual__icon" icon="chuo-logo"/>
         <span class="main-visual__title">{{ messages.MainVisual.Member }}</span>
       </template>
-    </main-visual-component>
+    </main-visual>
   </div>
 
   <section class="member__players">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Players.Main"
       :subTitle="messages.SectionTitles.Players.Sub"/>
 
@@ -20,7 +20,7 @@
           :key="n"
           @click="openModal(player)">
 
-        <user-ticket-component :userObj="player"/>
+        <user-ticket :userObj="player"/>
       </div>
       <!-- 左寄せに並べたいので空の要素をチケット分追加 -->
       <div
@@ -32,13 +32,13 @@
   </section>
 
   <section class="member__staff">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Staff.Main"
       :subTitle="messages.SectionTitles.Staff.Sub"/>
 
     <div class="ticket-group">
       <div class="ticket" ref="staffTicket" v-for="(staffItem, n) in staff" :key="n" @click="openModal(staffItem)">
-        <user-ticket-component :userObj="staffItem"/>
+        <user-ticket :userObj="staffItem"/>
       </div>
       <!-- 左寄せに並べたいので空の要素をチケット分追加 -->
       <div
@@ -50,7 +50,7 @@
     </div>
   </section>
 
-  <ticket-modal-component v-if="showModal" @close="closeModal" :item="clickElement"/>
+  <ticket-modal v-if="showModal" @close="closeModal" :item="clickElement"/>
 
   <div class="member__scroll-top">
     <scroll-top-button/>
@@ -61,22 +61,22 @@
 
 <script>
 // component import
-import MainVisualComponent from '../components/contents/MainVisualComponent';
+import MainVisual from '../components/contents/MainVisualComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
-import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
-import TicketModalComponent from '../components/modules/modal/TicketModalComponent.vue';
+import ContentsTitle from '../components/modules/ContentsTitleComponent';
+import TicketModal from '../components/modules/modal/TicketModalComponent.vue';
 import TableComponent from '../components/modules/table/TableComponent.vue';
-import UserTicketComponent from '../components/modules/ticket/UserTicketComponent';
+import UserTicket from '../components/modules/ticket/UserTicketComponent';
 
 // data import
 import Data from '../config/data.json';
 
 export default {
   components: {
-    MainVisualComponent,
-    ContentsTitleComponent,
-    UserTicketComponent,
-    TicketModalComponent,
+    MainVisual,
+    ContentsTitle,
+    UserTicket,
+    TicketModal,
     TableComponent,
     ScrollTopButton,
   },

--- a/src/resources/js/views/Member.vue
+++ b/src/resources/js/views/Member.vue
@@ -52,12 +52,17 @@
 
   <ticket-modal-component v-if="showModal" @close="closeModal" :item="clickElement"/>
 
+  <div class="member__scroll-top">
+    <scroll-top-button/>
+  </div>
+
 </div>
 </template>
 
 <script>
 // component import
 import MainVisualComponent from '../components/contents/MainVisualComponent';
+import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
 import TicketModalComponent from '../components/modules/modal/TicketModalComponent.vue';
 import TableComponent from '../components/modules/table/TableComponent.vue';
@@ -73,6 +78,7 @@ export default {
     UserTicketComponent,
     TicketModalComponent,
     TableComponent,
+    ScrollTopButton,
   },
   data() {
     return {
@@ -188,6 +194,10 @@ export default {
   &__staff {
     padding-bottom: interval(10);
     margin-bottom: 0;
+  }
+
+  &__scroll-top {
+    @include scroll-top();
   }
 }
 

--- a/src/resources/js/views/Photo.vue
+++ b/src/resources/js/views/Photo.vue
@@ -2,22 +2,22 @@
 <div class="photo">
   <!-- フォトギャラリー -->
   <section class="photo__gallery">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Photo.Main"
       :subTitle="messages.SectionTitles.Photo.Sub"/>
 
-    <images-component :images="images" :filter="config.filter"/>
+    <images :images="images" :filter="config.filter"/>
   </section>
 
   <!-- プロバイダー -->
   <section class="photo__provider">
-    <contents-title-component
+    <contents-title
       :title="messages.SectionTitles.Provider.Main"
       :subTitle="messages.SectionTitles.Provider.Sub"/>
 
     <div class="ticket-group">
       <div class="ticket" v-for="(provider, n) in providers" :key="n" ref="providerTicket" @click="openModal(provider)">
-        <provider-ticket-component :providerObj="provider"/>
+        <provider-ticket :providerObj="provider"/>
       </div>
       <!-- 左寄せに並べたいので空の要素をチケット分追加 -->
       <div
@@ -27,7 +27,7 @@
         :style="{ width: `${ticketWidth}px` }"/>
     </div>
 
-    <provider-ticket-modal-component v-if="showModal" @close="closeModal" :item="clickElement"/>
+    <provider-ticket-modal v-if="showModal" @close="closeModal" :item="clickElement"/>
 
     <div class="photo__scroll-top">
       <scroll-top-button/>
@@ -38,23 +38,23 @@
 </template>
 
 <script>
-// component import
-import ContentsTitleComponent from '../components/modules/ContentsTitleComponent';
-import ImagesComponent from '../components/contents/ImagesComponent';
-import ProviderTicketComponent from '../components/modules/ticket/ProviderTicketComponent';
-import ProviderTicketModalComponent from '../components/modules/modal/ProviderTicketModalComponent';
-
 // config json import
 import Data from '../config/data.json';
 import Config from '../config/config.json';
+
+// component import
+import ContentsTitle from '../components/modules/ContentsTitleComponent';
+import Images from '../components/contents/ImagesComponent';
+import ProviderTicket from '../components/modules/ticket/ProviderTicketComponent';
+import ProviderTicketModal from '../components/modules/modal/ProviderTicketModalComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
-    ContentsTitleComponent,
-    ImagesComponent,
-    ProviderTicketComponent,
-    ProviderTicketModalComponent,
+    ContentsTitle,
+    Images,
+    ProviderTicket,
+    ProviderTicketModal,
     ScrollTopButton,
   },
   data() {

--- a/src/resources/js/views/Photo.vue
+++ b/src/resources/js/views/Photo.vue
@@ -29,6 +29,10 @@
 
     <provider-ticket-modal-component v-if="showModal" @close="closeModal" :item="clickElement"/>
 
+    <div class="photo__scroll-top">
+      <scroll-top-button/>
+    </div>
+
   </section>
 </div>
 </template>
@@ -43,6 +47,7 @@ import ProviderTicketModalComponent from '../components/modules/modal/ProviderTi
 // config json import
 import Data from '../config/data.json';
 import Config from '../config/config.json';
+import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
@@ -50,6 +55,7 @@ export default {
     ImagesComponent,
     ProviderTicketComponent,
     ProviderTicketModalComponent,
+    ScrollTopButton,
   },
   data() {
     return {
@@ -172,6 +178,10 @@ export default {
     @include mq(md) {
       margin-top: 0;
     }
+  }
+
+  &__scroll-top {
+    @include scroll-top();
   }
 }
 

--- a/src/resources/sass/_mixin.scss
+++ b/src/resources/sass/_mixin.scss
@@ -240,8 +240,9 @@
  */
 
 // scroll button common style
-@mixin scroll-button ($position: interval(2),$size: interval(6) ) {
+@mixin scroll-top ($position: interval(2),$size: interval(6) ) {
   position: fixed;
+  z-index: 10;
   bottom: $position;
   right: $position;
   width: $size;

--- a/src/resources/sass/_mixin.scss
+++ b/src/resources/sass/_mixin.scss
@@ -53,7 +53,7 @@
   }
 }
 
-// image trim (imgタグの一つ親のタグに指定する)
+// image trimming (imgタグの一つ親のタグに指定する)
 @mixin trimming($aspect) {
   position: relative;
 
@@ -233,6 +233,19 @@
     left: 50%;
     transform: translate(-50%, -50%);
   }
+}
+
+/**
+ * page
+ */
+
+// scroll button common style
+@mixin scroll-button ($position: interval(2),$size: interval(6) ) {
+  position: fixed;
+  bottom: $position;
+  right: $position;
+  width: $size;
+  height: $size;
 }
 
 /**


### PR DESCRIPTION
## 概要
### スクロールボタンの作成
スクロールボタンは、ページ単位でよぶ。
各ページにマークアップ、スタイル、処理を記述すると面倒なのでコンポーネント化。
スタイルはミックスインを使用して登録。

### コンポーネントのインポート名変更。
各ページ、コンポーネントでインポート名を修正。
> `MainVisualComponent` -> `MainVisual`

とすることで、コンポーネントタグの冗長化を防ぐ。