### PR TITLE
写真モーダルの「次へ戻る」ボタンのアニメーション追加

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -7329,6 +7329,12 @@ import用ファイル
 .prev-leave[data-v-213a8ec6] {
   transform: translateX(0);
   opacity: 0;
+}
+.button-enter-active[data-v-213a8ec6], .button-leave-active[data-v-213a8ec6] {
+  transition: opacity 0.5s;
+}
+.button-enter[data-v-213a8ec6], .button-leave-to[data-v-213a8ec6] {
+  opacity: 0;
 }@charset "UTF-8";
 /*
 import用ファイル

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=47abf5d20466b37085f4",
-    "/css/app.css": "/css/app.css?id=6eedfff0c7722870faa7"
+    "/js/app.js": "/js/app.js?id=c671b40b1397dca8dc1c",
+    "/css/app.css": "/css/app.css?id=194ee28e51eb29009579"
 }

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=c671b40b1397dca8dc1c",
+    "/js/app.js": "/js/app.js?id=8f5e5712b211658d66c3",
     "/css/app.css": "/css/app.css?id=194ee28e51eb29009579"
 }

--- a/src/resources/js/components/modules/modal/ImageModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ImageModalComponent.vue
@@ -17,17 +17,23 @@
           </transition>
 
           <footer class="image-modal__footer" v-if="footerShow">
-            <div class="image-modal__prev-btn-area" @click="prevImage" v-if="showPrevBtn">
-              <button class="image-modal__prev-btn">
-                <svg-vue icon="arrow-left" class="image-modal__icon"/>
-              </button>
-            </div>
 
-            <div class="image-modal__next-btn-area" @click="nextImage" v-if="showNextBtn">
-              <button class="image-modal__next-btn">
-                <svg-vue icon="arrow-right" class="image-modal__icon"/>
-              </button>
-            </div>
+            <transition name="button">
+              <div class="image-modal__prev-btn-area" @click="prevImage" v-if="showPrevBtn">
+                  <button class="image-modal__prev-btn">
+                    <svg-vue icon="arrow-left" class="image-modal__icon"/>
+                  </button>
+              </div>
+            </transition>
+
+            <transition name="button">
+              <div class="image-modal__next-btn-area" @click="nextImage" v-if="showNextBtn">
+                  <button class="image-modal__next-btn">
+                    <svg-vue icon="arrow-right" class="image-modal__icon"/>
+                  </button>
+              </div>
+            </transition>
+
           </footer>
         </div>
 
@@ -364,4 +370,15 @@ export default {
   opacity: 0;
 }
 
+.button {
+  &-enter-active,
+  &-leave-active {
+    transition: opacity .5s;
+  }
+
+  &-enter,
+  &-leave-to {
+    opacity: 0;
+  }
+}
 </style>

--- a/src/resources/js/views/Member.vue
+++ b/src/resources/js/views/Member.vue
@@ -109,6 +109,7 @@ export default {
       ticketWidth: 0,
     }
   },
+
   beforeMount() {
     // TODO:以下DBから情報を引っ張る
 
@@ -140,11 +141,9 @@ export default {
     this.staffTicketNumber = staffTicket.length;
 
     /**
-     * 1.描画後にチケットの幅を取得（デフォ値を代入）
-     * 2.チケットのサイズをリアルタイムで取得
+     * 初期描画時のにチケットの幅を取得
      */
     this.getTicketWidth();
-    window.addEventListener('resize', this.getTicketWidth);
   },
 
   methods: {
@@ -170,13 +169,11 @@ export default {
     },
   },
 
-  beforeDestroy() {
-    /**
-     * 登録したイベントを破棄
-     * ! 無名関数はイベント解除できないので注意
-     */
-    window.removeEventListener('resize', this.getTicketWidth);
-  },
+  watch: {
+    windowWidth() {
+      this.getTicketWidth();
+    }
+  }
 }
 </script>
 

--- a/src/resources/js/views/Photo.vue
+++ b/src/resources/js/views/Photo.vue
@@ -114,9 +114,8 @@ export default {
     // チケットの要素数を取得 (チケットが一枚の時はenpty要素を増やさない)
     if(ticket.length > 1) this.ticketNumber = ticket.length;
 
-    // チケットのwidthを取得
+    // 初期描画時のチケットwidthを取得
     this.getTicketWidth();
-    window.addEventListener('resize', this.getTicketWidth);
   },
 
   methods: {
@@ -142,9 +141,10 @@ export default {
     },
   },
 
-  beforeDestroy() {
-    // 登録したイベントを破棄
-    window.removeEventListener('resize', this.getTicketWidth);
+  watch: {
+    windowWidth() {
+      this.getTicketWidth();
+    }
   },
 }
 


### PR DESCRIPTION
## 概要
### 写真モーダルの遷移ボタンにアニメーションを追加
消える時と表示される時にフェードアニメーションを追加。

### メンバーページのチケット幅取得処理を修正
チケットの幅をリアルタイムで取得する処理をイベント登録からwatchプロパティで管理する方法に変更。