### PR TITLE
homeのアバウトセクションにスクロールアニメーションを追加。

### DIFF
--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -20913,3 +20913,11 @@ th, td {
   margin-top: 0;
   margin-bottom: 0;
 }
+
+/**
+ * 表示の際にふわっと表示させるアニメーションに指定するクラス
+ */
+.animated {
+  opacity: 0;
+  transition: 1s opacity cubic-bezier(0.39, 0.575, 0.565, 1), 1.3s transform cubic-bezier(0.39, 0.575, 0.565, 1);
+}

--- a/src/public/mix-manifest.json
+++ b/src/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=926156025858ee52d625",
-    "/css/app.css": "/css/app.css?id=8a44e8bdb2b534a87b69"
+    "/js/app.js": "/js/app.js?id=ce3ce292519dbfc806a9",
+    "/css/app.css": "/css/app.css?id=32431881f99f06f3f476"
 }

--- a/src/resources/js/app.js
+++ b/src/resources/js/app.js
@@ -35,6 +35,20 @@ import vueAxios from 'vue-axios';
 Vue.use(vueAxios, axios);
 
 /**
+ * スクロールアニメーションのカスタムディレクティブを作成。
+ */
+Vue.directive('scroll', {
+  inserted: function (el, binding) {
+    let f = function (evt) {
+      if (binding.value(evt, el)) {
+        window.removeEventListener('scroll', f)
+      }
+    }
+    window.addEventListener('scroll', f)
+  }
+})
+
+/**
  * components (全ページで使う共通コンポーネント)
  */
 import HeaderComponent from './components/layouts/HeaderComponent';

--- a/src/resources/js/config/global.js
+++ b/src/resources/js/config/global.js
@@ -87,5 +87,22 @@ export default {
       this.windowWidth = window.innerWidth;
       this.windowHeight = window.innerHeight;
     },
+
+    /**
+     * スクロールアニメーション
+     * @param2 {el} ディレクティブを指定した要素のDOMが入る。
+     */
+    handleScroll(evt, el) {
+      // アニメーションの
+      let top = el.getBoundingClientRect().top;
+      let trigger = this.windowHeight / 2;
+
+      if (top < trigger) {
+        el.setAttribute(
+          'style',
+          'opacity: 1; transform: translate3d(0, -10px, 0)'
+        )
+      }
+    }
   },
 }

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -9,14 +9,14 @@
     </section>
 
     <section class="home__about">
-      <div class="about" v-for="(item, n) in aboutContents" :key="n">
+      <div class="about" v-for="(item, n) in aboutContents" :key="n" ref="about">
 
         <figure class="about__img">
           <img :src="`/image/${item.img.src}.jpg`" :alt="item.img.alt">
         </figure>
 
         <div class="about__box">
-          <div class="about__content">
+          <div class="about__content animated" v-scroll="handleScroll">
             <div class="about__title">
               <contents-title :title="item.title"/>
             </div>
@@ -100,6 +100,13 @@ export default {
         if (el.title === element.key) el.title = element.value;
       });
     });
+  },
+
+  mounted() {
+    this.$refs.about.forEach((element) => {
+      let top = element.getBoundingClientRect().top;
+      console.log(element);
+    })
   },
 
   methods: {

--- a/src/resources/sass/foundation/_base.scss
+++ b/src/resources/sass/foundation/_base.scss
@@ -161,3 +161,13 @@ th,td {
   margin-top: 0;
   margin-bottom: 0;
 }
+
+/**
+ * 表示の際にふわっと表示させるアニメーションに指定するクラス
+ */
+.animated {
+  opacity: 0;
+  transition:
+    1.0s opacity cubic-bezier(0.39, 0.575, 0.565, 1),
+    1.3s transform cubic-bezier(0.39, 0.575, 0.565, 1);
+}


### PR DESCRIPTION
## 概要
スクロールアニメーションは、インラインスタイルの上書きをすることでアニメーションを実行する。（フラグを立てずに実行することでコード量を減らす。）
サイト内でスクロールアニメーションの統一化を考慮して、カスタムディレクティブを作成。

### スクロールアニメーション用のカスタムディレクティブを追加。
テンプレートのDOM要素に`v-scroll="method"`で使用可能。
app.jsでVueインスタンスを作成する前に追加。

### スクロールアニメーションのメソッドをglobal.jsに追加。
スクロールアニメーションの処理をglobal.jsに追加。
アニメーションの開始座標は、ターゲット要素の上部がウインドウ高さの半分に到達したポイント。

### スクロールアニメーションの適用する要素に指定するクラスを作成。
スクロールアニメーションを適用したい箇所に、`animated`クラスを付与する。