### PR TITLE
ルート要素のfont sizeを見直し

### DIFF
--- a/src/resources/js/components/contents/NewsComponent.vue
+++ b/src/resources/js/components/contents/NewsComponent.vue
@@ -244,7 +244,7 @@ export default {
 
   &__btn {
     @include mq(sm) {
-      max-width: 80%;
+      max-width: interval(50);
       margin: 0 auto;
     }
   }

--- a/src/resources/js/components/contents/NewsComponent.vue
+++ b/src/resources/js/components/contents/NewsComponent.vue
@@ -234,6 +234,7 @@ export default {
 
   &__text {
     display: block;
+    font-size: font(12);
     margin-bottom: interval(5);
 
     @include mq(sm) {

--- a/src/resources/js/components/contents/NewsComponent.vue
+++ b/src/resources/js/components/contents/NewsComponent.vue
@@ -244,7 +244,7 @@ export default {
 
   &__btn {
     @include mq(sm) {
-      max-width: interval(50);
+      max-width: 80%;
       margin: 0 auto;
     }
   }

--- a/src/resources/js/components/layouts/FooterComponent.vue
+++ b/src/resources/js/components/layouts/FooterComponent.vue
@@ -133,7 +133,7 @@ export default {
 
   &__contact-btn {
     @include mq(sm) {
-      max-width: 60%;
+      max-width: interval(50);
       margin: 0 auto;
     }
   }

--- a/src/resources/js/components/layouts/FooterComponent.vue
+++ b/src/resources/js/components/layouts/FooterComponent.vue
@@ -133,7 +133,7 @@ export default {
 
   &__contact-btn {
     @include mq(sm) {
-      max-width: interval(50);
+      max-width: 60%;
       margin: 0 auto;
     }
   }

--- a/src/resources/js/components/layouts/HeaderComponent.vue
+++ b/src/resources/js/components/layouts/HeaderComponent.vue
@@ -234,7 +234,6 @@ export default {
 
   &__button {
     position: relative;
-    @include flex(row nowrap, center, center);
     background-color: color(darkblue);
     width: interval(5);
     height: interval(5);
@@ -248,18 +247,24 @@ export default {
     }
 
     @include mq(md) {
+      max-width: pixel(10);
+      max-height: pixel(10);
       margin: 0 0 pixel(1) 0;
     }
 
     @include hover {
       .header__icon {
-        transform: rotateZ(360deg);
+        transform: translate(-50%, -50%) rotateZ(360deg);
       }
     }
   }
 
   &__icon {
-    width: interval(2.5);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotateZ(0);
+    width: 50%;
     fill: color(white);
     color: color(white);
     transition: .3s all ease-out;

--- a/src/resources/js/components/layouts/HeaderComponent.vue
+++ b/src/resources/js/components/layouts/HeaderComponent.vue
@@ -247,8 +247,8 @@ export default {
     }
 
     @include mq(md) {
-      width: interval(7);
-      height: interval(7);
+      width: interval(6);
+      height: interval(6);
       max-width: pixel(10);
       max-height: pixel(10);
       margin: 0 0 pixel(1) 0;

--- a/src/resources/js/components/layouts/HeaderComponent.vue
+++ b/src/resources/js/components/layouts/HeaderComponent.vue
@@ -247,6 +247,8 @@ export default {
     }
 
     @include mq(md) {
+      width: interval(7);
+      height: interval(7);
       max-width: pixel(10);
       max-height: pixel(10);
       margin: 0 0 pixel(1) 0;

--- a/src/resources/js/components/modules/accordion/AccordionLinkComponent.vue
+++ b/src/resources/js/components/modules/accordion/AccordionLinkComponent.vue
@@ -155,7 +155,7 @@ export default {
   &__label {
     cursor: pointer;
     transition: all .3s ease-out;
-    font-size: font(16);
+    font-size: font(14);
   }
 
   &__icon-wrap {

--- a/src/resources/js/components/modules/button/LinkButtonComponent.vue
+++ b/src/resources/js/components/modules/button/LinkButtonComponent.vue
@@ -99,7 +99,7 @@ export default {
     padding: interval(2.5);
     @extend %frame;
     @include flex(row nowrap, center, center);
-    transform: translateX(-4px) translateY(4px);
+    transform: translateX(- interval(.5)) translateY(interval(.5));
   }
 
   &__name {

--- a/src/resources/js/components/modules/button/PrimaryButtonComponent.vue
+++ b/src/resources/js/components/modules/button/PrimaryButtonComponent.vue
@@ -63,7 +63,7 @@ export default {
     height: 100%;
     padding: interval(2.5);
     @extend %frame;
-    transform: translateX(-4px) translateY(4px);
+    transform: translateX(- interval(.5)) translateY(interval(.5));
     @include flex(row nowrap, center, center);
   }
 

--- a/src/resources/js/components/modules/button/ViewAllButtonComponent.vue
+++ b/src/resources/js/components/modules/button/ViewAllButtonComponent.vue
@@ -40,7 +40,6 @@ export default {
 <style lang="scss">
 .view-all {
   color: color(white);
-  width: 70%;
   margin: 0 auto;
 
   @include mq(sm) {
@@ -51,7 +50,7 @@ export default {
     width: 100%;
     position: relative;
     padding: interval(3) interval(6);
-    border-radius: 100px;
+    border-radius: 200px;
     transition: all .3s ease-out;
     box-shadow: 0 15px 13px -15px darken($color: color(orange), $amount: 3%);
     @include flex(row nowrap, center, center);

--- a/src/resources/js/components/modules/modal/ImageModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ImageModalComponent.vue
@@ -5,8 +5,8 @@
 
         <div class="image-modal">
           <header class="image-modal__header">
-            <button class="image-modal__close-btn" @click="$emit('close')">
-              <i class="btn-line"/>
+            <button class="image-modal__button" @click="$emit('close')">
+              <svg-vue icon="close"/>
             </button>
           </header>
 
@@ -228,7 +228,7 @@ export default {
     top: interval(2);
   }
 
-  &__close-btn {
+  &__button {
     @include close-button;
   }
 

--- a/src/resources/js/components/modules/modal/ModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ModalComponent.vue
@@ -3,9 +3,11 @@
     <div class="modal" @click.self="$emit('close')">
       <div class="modal-window" @click.self="$emit('close')">
 
-        <button class="modal__btn" @click="$emit('close')">
-          <i class="btn-line"/>
-        </button>
+        <div class="modal__close">
+          <button class="modal__button" @click="$emit('close')">
+            <svg-vue icon="close"/>
+          </button>
+        </div>
 
         <slot name="content"/>
 
@@ -41,12 +43,15 @@ export default {
     overflow-y: auto;
   }
 
-  &__btn {
-    @include close-button;
-    background-color: color(orange);
+  &__close {
     position: fixed;
     top: interval(2);
     right: interval(2);
+  }
+
+  &__button {
+    @include close-button;
+    background-color: color(orange);
 
     @include mq(md) {
       background-color: rgba($color: #000000, $alpha: 0);

--- a/src/resources/js/components/modules/modal/NavModalComponent.vue
+++ b/src/resources/js/components/modules/modal/NavModalComponent.vue
@@ -12,7 +12,7 @@
         <header class="nav-modal__header" @click="$emit('close')">
           <svg-vue icon="hakumonkai-logo" class="nav-modal__logo"/>
           <button class="nav-modal__btn">
-            <i class="btn-line"/>
+            <svg-vue icon="close"/>
           </button>
         </header>
 
@@ -258,7 +258,7 @@ export default {
   &__menu-title {
     cursor: pointer;
     transition: all .3s ease-out;
-    font-size: font(16);
+    font-size: font(14);
   }
 
   &__menu-icon {

--- a/src/resources/js/components/modules/modal/NavModalComponent.vue
+++ b/src/resources/js/components/modules/modal/NavModalComponent.vue
@@ -262,7 +262,7 @@ export default {
   }
 
   &__menu-icon {
-    width: interval(1);
+    width: interval(1.5);
     fill: color(white);
     cursor: pointer;
   }
@@ -273,7 +273,7 @@ export default {
     margin-top: interval(5);
 
     @include mq(sm) {
-      max-width: interval(45);
+      max-width: interval(40);
       margin: interval(5) 0 0 auto;
     }
   }

--- a/src/resources/js/components/modules/modal/ProviderTicketModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ProviderTicketModalComponent.vue
@@ -5,9 +5,11 @@
 
         <div class="ticket-modal">
           <div class="ticket-modal__container">
-            <button class="ticket-modal__close-btn" @click="$emit('close')">
-              <i class="btn-line"/>
-            </button>
+            <div class="ticket-modal__close">
+              <button class="ticket-modal__button" @click="$emit('close')">
+                <svg-vue icon="close"/>
+              </button>
+            </div>
 
             <div class="ticket-modal__content">
               <div class="ticket-modal__header">
@@ -123,11 +125,14 @@ export default {
     }
   }
 
-  &__close-btn {
-    @include close-button(pixel(5), color(darkblue));
+  &__close {
     position: absolute;
     right: interval(2);
     top: interval(2);
+  }
+
+  &__button {
+    @include close-button($color: color(darkblue));
   }
 
   &__content {

--- a/src/resources/js/components/modules/modal/TicketModalComponent.vue
+++ b/src/resources/js/components/modules/modal/TicketModalComponent.vue
@@ -5,9 +5,11 @@
 
         <div class="ticket-modal">
           <div class="ticket-modal__container">
-            <button class="ticket-modal__close-btn" @click="$emit('close')">
-              <i class="btn-line"/>
-            </button>
+            <div class="ticket-modal__close">
+              <button class="ticket-modal__button" @click="$emit('close')">
+                <svg-vue icon="close"/>
+              </button>
+            </div>
 
             <div class="ticket-modal__content">
               <div class="ticket-modal__header">
@@ -192,11 +194,14 @@ export default {
     }
   }
 
-  &__close-btn {
-    @include close-button($color: color(darkblue));
+  &__close {
     position: absolute;
     right: interval(2);
     top: interval(2);
+  }
+
+  &__button {
+    @include close-button($color: color(darkblue));
   }
 
   &__content {
@@ -300,7 +305,6 @@ export default {
   &__line {
     width: 100%;
     height: 2px;
-    // @include gradient(color(deepDarkblue), color(white), horizontal);
     background-color: color(lightgray);
   }
 

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -125,8 +125,12 @@ export default {
   position: relative;
 
   &__news {
-    transform: translateY(-50px);
-    max-width: interval(100);
+    transform: translateY(- interval(15));
+    margin-bottom: 0;
+
+    @include mq(md) {
+      max-width: 80%;
+    }
   }
 
   &__about {

--- a/src/resources/js/views/Home.vue
+++ b/src/resources/js/views/Home.vue
@@ -263,7 +263,7 @@ export default {
     width: 100%;
 
     @include mq(sm) {
-      max-width: interval(50);
+      max-width: 80%;
       margin: 0 auto;
     }
   }

--- a/src/resources/js/views/Member.vue
+++ b/src/resources/js/views/Member.vue
@@ -264,7 +264,7 @@ export default {
     width: interval(36);
     fill: color(white);
     stroke: color(orange);
-    stroke-width: interval(1);
+    stroke-width: pixel(1);
 
     @include mq(sm) {
       width: interval(28);

--- a/src/resources/sass/_mixin.scss
+++ b/src/resources/sass/_mixin.scss
@@ -158,44 +158,30 @@
  */
 
 // modal close button
-@mixin close-button($size: pixel(5), $color: color(white)) {
+@mixin close-button($size: interval(4), $color: color(white)) {
   position: relative;
   width: $size;
   height: $size;
   border-radius: radius(circle);
   @include flex(row nowrap, center, center);
-  transition: all .3s ease-out;
+  transition: background-color .3s ease-out;
 
-  & > i {
-    position: relative;
-    display: block;
-    background-color: $color;
-    width: calc( #{$size} / 2);
-    height: 3px;
-    transform: rotate(-45deg);
-    transition: all .3s ease-out;
-
-    &::before {
-      content: '';
-      display: block;
-      width: 100%;
-      height: 100%;
-      background-color: $color;
-      transform: rotate(90deg);
-      transition: all .3s ease-out;
-    }
+  & > svg {
+    fill: $color;
+    width: 60%;
+    height: 60%;
+    transition: fill .3s ease-out;
   }
 
   @include mq(md) {
-    // ボタンの色がグレーの時
+    // ボタンの色がネイビーの時
     @if $color == color(darkblue) {
       &:hover {
         background-color: color(darkblue);
       }
 
-      &:hover > .btn-line,
-      &:hover > .btn-line::before {
-        background-color: color(white);
+      &:hover > svg {
+        fill: color(white);
       }
     }
     // 基本のホバースタイル

--- a/src/resources/sass/foundation/_base.scss
+++ b/src/resources/sass/foundation/_base.scss
@@ -6,7 +6,7 @@ html {
   }
 
   @include mq(md) {
-    font-size: 2vw;
+    font-size: 1.4vw;
   }
 }
 

--- a/src/resources/sass/foundation/_base.scss
+++ b/src/resources/sass/foundation/_base.scss
@@ -6,7 +6,7 @@ html {
   }
 
   @include mq(md) {
-    font-size: 24px;
+    font-size: 2vw;
   }
 }
 
@@ -49,7 +49,6 @@ header {
 
 section {
   padding: 0 pixel(2);
-  max-width: device(max);
   margin: 0 auto interval(10) auto;
 
   @include mq(sm) {
@@ -57,20 +56,21 @@ section {
   }
 
   @include mq(md) {
-    padding: 0 pixel(4);
+    padding: 0 3vw;
   }
 }
 
 // セクションではないが、スタイルだけ適用したいとき。
 .wrapper {
   padding: 0 pixel(2);
+  margin: 0 auto interval(10) auto;
 
   @include mq(sm) {
     padding: 0 pixel(3);
   }
 
   @include mq(md) {
-    padding: 0 pixel(4);
+    padding: 0 3vw;
   }
 }
 


### PR DESCRIPTION
## 概要
### PCの時のfont sizeをvwで指定。
上記の対応をすることで、画面幅が大きくなっても比率が保たれる。
ルート要素のfontsizeを変えたことで、各コンポーネントのサイズ調整を実施。

固定値で持ちたい箇所は、`pixel( )`を使用し、可変（rem）で持ちたい箇所は、`interval( )`を使用する。