### PR TITLE
スワイパーのレイアウトを修正

### DIFF
--- a/src/resources/js/components/modules/slider/ImageSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/ImageSliderComponent.vue
@@ -42,7 +42,7 @@ export default {
 
         pagination: {
           el: '.swiper-pagination',
-          clickable: true,
+          clickable: false,
           type: 'bullets',
         }
       }
@@ -83,7 +83,7 @@ export default {
 
   .swiper {
     &-container {
-      padding-bottom: interval(4);
+      padding-bottom: interval(3);
     }
 
     &-button-next,
@@ -110,6 +110,22 @@ export default {
 
     &-pagination-bullets {
       bottom: 0;
+
+      // ページネーションの丸は、スロットで読まれるためディープセレクタにすることでスタイルが当たる
+      &::v-deep .swiper-pagination-bullet {
+        opacity: 1;
+        position: relative;
+        width: interval(5);
+        height: 3px;
+        border-radius: 0;
+        margin: 0 interval(.5);
+        background-color: rgba(color(darkblue), .2);
+        transition: background-color .3s ease;
+      }
+
+      &::v-deep .swiper-pagination-bullet-active {
+        background-color: color(lightDarkblue);
+      }
     }
   }
 }

--- a/src/resources/js/components/modules/slider/ImageSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/ImageSliderComponent.vue
@@ -14,9 +14,11 @@
 
         </figure>
       </swiper-slide>
-      <div class="swiper-button swiper-button-prev" slot="button-prev"></div>
-      <div class="swiper-button swiper-button-next" slot="button-next"></div>
-      <div class="swiper-pagination" slot="pagination"></div>
+
+      <!-- swiper components -->
+      <div class="swiper-button swiper-button-prev" slot="button-prev"/>
+      <div class="swiper-button swiper-button-next" slot="button-next"/>
+      <div class="swiper-pagination" slot="pagination"/>
     </swiper>
   </div>
 </template>
@@ -82,53 +84,8 @@ export default {
   }
 
   .swiper {
-    &-container {
-      padding-bottom: interval(3);
-    }
-
-    &-button-next,
-    &-button-prev {
-      width: interval(6);
-      height: interval(6);
-      border: 1px solid color(lightgray);
-      border-radius: radius(circle);
-      outline: none;
-      transform: translateY(- interval(2));
-
-      &::after {
-        content: '';
-      }
-    }
-
-    &-button-next {
-      @include background-image('data:image/svg+xml;utf8,#{$arrow-right}', center center, interval(3));
-      right: interval(.5);
-    }
-
-    &-button-prev {
-      @include background-image('data:image/svg+xml;utf8,#{$arrow-left}', center center, interval(3));
-      left: interval(.5);
-    }
-
-    &-pagination-bullets {
-      bottom: 0;
-
-      // ページネーションの丸は、スロットで読まれるためディープセレクタにすることでスタイルが当たる
-      &::v-deep .swiper-pagination-bullet {
-        opacity: 1;
-        position: relative;
-        width: interval(5);
-        height: 3px;
-        border-radius: 0;
-        margin: 0 interval(.5);
-        background-color: rgba(color(darkblue), .2);
-        transition: background-color .3s ease;
-      }
-
-      &::v-deep .swiper-pagination-bullet-active {
-        background-color: color(lightDarkblue);
-      }
-    }
+    @include swiper-pagination();
+    @include swiper-button();
   }
 }
 </style>

--- a/src/resources/js/components/modules/slider/ImageSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/ImageSliderComponent.vue
@@ -102,10 +102,12 @@ export default {
 
     &-button-next {
       @include background-image('data:image/svg+xml;utf8,#{$arrow-right}', center center, interval(3));
+      right: interval(.5);
     }
 
     &-button-prev {
       @include background-image('data:image/svg+xml;utf8,#{$arrow-left}', center center, interval(3));
+      left: interval(.5);
     }
 
     &-pagination-bullets {

--- a/src/resources/js/components/modules/slider/ImageSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/ImageSliderComponent.vue
@@ -14,9 +14,9 @@
 
         </figure>
       </swiper-slide>
+      <div class="swiper-button swiper-button-prev" slot="button-prev"></div>
+      <div class="swiper-button swiper-button-next" slot="button-next"></div>
       <div class="swiper-pagination" slot="pagination"></div>
-      <!-- <div class="swiper-button swiper-button-prev" slot="button-prev"></div>
-      <div class="swiper-button swiper-button-next" slot="button-next"></div> -->
     </swiper>
   </div>
 </template>
@@ -31,26 +31,20 @@ export default {
     params() {
       return {
         loop: true, // ループ
-        speed: 1500,  // スライドする時間
-        effect: "coverflow",  // スライドタイプ
+        speed: 800,  // スライドする時間
+        effect: "fade",  // スライドタイプ
         autoHeight: true,
 
-        autoplay: {
-          delay: 2500,
-        },
-
-        // ナビゲーション
         navigation: {
-          nextEl: '.c-imageSlider .swiper-button-next',
-          prevEl: '.c-imageSlider .swiper-button-prev',
+          nextEl: '.swiper-button-next',
+          prevEl: '.swiper-button-prev',
         },
 
-        // ページネーション
         pagination: {
-          el: '.c-imageSlider .swiper-pagination',
+          el: '.swiper-pagination',
           clickable: true,
-          type: 'progressbar',
-        },
+          type: 'bullets',
+        }
       }
     }
   },
@@ -61,7 +55,7 @@ export default {
 .image-slider {
 
   &__container {
-    @include trimming(aspect(rectangle));
+    @include trimming(aspect(golden));
 
     // 上のincludeで指定済みだが、&-caption でポジション指定しているので関係がわかりやすくなるように記述。
     position: relative;
@@ -84,6 +78,38 @@ export default {
 
     @include mq(sm) {
       line-height: 2;
+    }
+  }
+
+  .swiper {
+    &-container {
+      padding-bottom: interval(4);
+    }
+
+    &-button-next,
+    &-button-prev {
+      width: interval(6);
+      height: interval(6);
+      border: 1px solid color(lightgray);
+      border-radius: radius(circle);
+      outline: none;
+      transform: translateY(- interval(2));
+
+      &::after {
+        content: '';
+      }
+    }
+
+    &-button-next {
+      @include background-image('data:image/svg+xml;utf8,#{$arrow-right}', center center, interval(3));
+    }
+
+    &-button-prev {
+      @include background-image('data:image/svg+xml;utf8,#{$arrow-left}', center center, interval(3));
+    }
+
+    &-pagination-bullets {
+      bottom: 0;
     }
   }
 }

--- a/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
@@ -50,11 +50,11 @@ export default {
         },
         on: {
           // cssアニメーションに合わせる
-          slideChange() {
-            if (this.realIndex > 0) {
-              this.params.autoplay.delay = 4100;
-            }
-          },
+          // slideChange() {
+          //   if (this.realIndex > 0) {
+          //     this.params.autoplay.delay = 4100;
+          //   }
+          // },
         },
         allowTouchMove: false,
       }
@@ -122,7 +122,7 @@ export default {
     width: interval(8);
     height: pixel(.5);
     margin: 0 interval(1);
-    background-color: rgba($color: #000000, $alpha: .5);
+    background-color: rgba($color: color(darkblue), $alpha: .5);
     border-radius: 1000px;
 
     &::before {
@@ -131,13 +131,10 @@ export default {
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
+      width: 50%;
       height: 100%;
       background-color: color(white);
-      border-radius: 1000px;
-      transform: scaleX(0);
-      transform-origin: 0 0;
-      animation: gauge 4.5s linear infinite;
+      border-radius: 1000px 0 0 1000px;
     }
   }
 

--- a/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
@@ -1,9 +1,19 @@
 <template>
 <div class="main-visual-slider">
     <swiper ref="mainVisualSwiper" :options="params">
-      <swiper-slide v-for="(image, n) in images" :key="n">
+      <swiper-slide v-for="(image,i) in images" :key="i">
         <img class="main-visual-slider__image" :src="`/image/${image.src}`" :alt="image.alt">
-        <span class="main-visual-slider__text">{{ image.caption }}</span>
+
+        <div class="main-visual-slider__box">
+          <span class="main-visual-slider__text">{{ image.caption }}</span>
+
+          <div class="main-visual-slider__pagination">
+            <span class="main-visual-slider__num">{{ convert(i) }}</span>
+            <div class="main-visual-slider__bar"/>
+            <span class="main-visual-slider__num">{{ next(i + 1) }}</span>
+          </div>
+        </div>
+
       </swiper-slide>
     </swiper>
   </div>
@@ -11,8 +21,21 @@
 
 <script>
 export default {
+  data() {
+    return {
+      /**
+       * images配列の最大個数を格納
+       */
+      max: [],
+    }
+  },
+
   props: {
     images: Array,
+  },
+
+  mounted() {
+    this.max = this.images.length;
   },
 
   computed: {
@@ -22,33 +45,29 @@ export default {
         speed: 2000,
         effect: "fade",
         autoplay: {
-          delay: 2500,
+          delay: 3500,
           disableOnInteraction: false,  // スワイプ後に自動再生がオンのまま
-        },
-        navigation: {
-          nextEl: '.main-visual-slider .swiper-button-next',
-          prevEl: '.main-visual-slider .swiper-button-prev',
-        },
-        pagination: {
-          el: '.main-visual-slider .swiper-pagination',
-          clickable: true,
         },
         scrollbar: {
           el: '.swiper-scrollbar',
         },
-        breakpoints: {
-          // 560px 以上の時
-          560: {
-            // hoge
-          },
-          // 993px 以上の時
-          993: {
-            // hoge
-          }
-        }
-
       }
     },
+
+    convert() {
+      return (i) => {
+        let index = i + 1;
+        return ("00" + index).slice(-2);
+      };
+    },
+
+    next() {
+      return (i) => {
+        let nextIndex = i + 1;
+        return (this.max >= nextIndex) ? ("00" + nextIndex).slice(-2) : ("00" + 1).slice(-2);
+      }
+    },
+
   },
 }
 </script>
@@ -72,20 +91,50 @@ export default {
     object-position: 50% 50%;
   }
 
-  &__text {
+  &__box {
     position: absolute;
     top: 50%;
-    left: 0;
+    left: interval(2);
     z-index: 10;
     color: color(white);
-    padding-left: interval(2);
-    font-size: font(12);
 
-    @include mq(sm) {
-      left: 5%;
-      padding-left: 0;
-      font-size: font(16);
+    @include mq(md) {
+      left: interval(10);
     }
+  }
+
+  &__text {
+    font-size: font(14);
+  }
+
+  &__pagination {
+    @include flex(row nowrap, flex-start, center);
+    margin-top: interval(.5);
+  }
+
+  &__bar {
+    position: relative;
+    width: interval(8);
+    height: pixel(.5);
+    margin: 0 interval(1);
+    background-color: rgba($color: #000000, $alpha: .5);
+    border-radius: 1000px;
+
+    &::before {
+      content: '';
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 50%;
+      height: 100%;
+      background-color: color(white);
+      border-radius: 1000px 0 0 1000px;
+    }
+  }
+
+  &__num {
+    font-size: font(16);
   }
 }
 </style>

--- a/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/MainVisualSliderComponent.vue
@@ -42,15 +42,21 @@ export default {
     params() {
       return {
         loop: true,
-        speed: 2000,
+        speed: 400,
         effect: "fade",
         autoplay: {
-          delay: 3500,
-          disableOnInteraction: false,  // スワイプ後に自動再生がオンのまま
+          delay: 4500,
+          disableOnInteraction: false,
         },
-        scrollbar: {
-          el: '.swiper-scrollbar',
+        on: {
+          // cssアニメーションに合わせる
+          slideChange() {
+            if (this.realIndex > 0) {
+              this.params.autoplay.delay = 4100;
+            }
+          },
         },
+        allowTouchMove: false,
       }
     },
 
@@ -95,7 +101,6 @@ export default {
     position: absolute;
     top: 50%;
     left: interval(2);
-    z-index: 10;
     color: color(white);
 
     @include mq(md) {
@@ -126,10 +131,13 @@ export default {
       position: absolute;
       top: 0;
       left: 0;
-      width: 50%;
+      width: 100%;
       height: 100%;
       background-color: color(white);
-      border-radius: 1000px 0 0 1000px;
+      border-radius: 1000px;
+      transform: scaleX(0);
+      transform-origin: 0 0;
+      animation: gauge 4.5s linear infinite;
     }
   }
 

--- a/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="slider">
-    <swiper :options="params" :class="coloring">
+    <swiper :options="option" :class="coloring">
       <swiper-slide v-for="(player, n) in players" :key="n">
         <player-card :player="player">
           <template v-slot:addCardContents="player" v-if="player.category === activeAlumniNum">
@@ -36,51 +36,58 @@ export default {
       type: String,
       default: '',
     },
+
+    option: {
+      type: Object,
+      default: () => {
+        return {
+          loop: true, // ループ
+          speed: 1000,  // スライドする時間
+          autoHeight: true,
+
+          autoplay: {
+            delay: 2500,
+          },
+
+          navigation: {
+            nextEl: '.swiper-button-next',
+            prevEl: '.swiper-button-prev',
+          },
+
+          pagination: {
+            el: '.swiper-pagination',
+            clickable: true,
+            type: 'bullets',
+          },
+
+          breakpoints: {
+            500: {
+              slidesPerView: 2,
+              slidesPerGroup: 2,
+            },
+            860: {
+              slidesPerView: 3,
+              slidesPerGroup: 1,
+            },
+            1440: {
+              slidesPerView: 5,
+              slidesPerGroup: 1,
+            },
+          },
+        }
+      },
+    }
   },
 
   computed: {
-    params() {
-      return {
-        loop: true, // ループ
-        speed: 1000,  // スライドする時間
-        autoHeight: true,
-
-        autoplay: {
-          delay: 2500,
-        },
-
-        navigation: {
-          nextEl: '.swiper-button-next',
-          prevEl: '.swiper-button-prev',
-        },
-
-        pagination: {
-          el: '.swiper-pagination',
-          clickable: false,
-          type: 'bullets',
-        },
-
-        breakpoints: {
-          500: {
-            slidesPerView: 2,
-            slidesPerGroup: 2,
-          },
-          860: {
-            slidesPerView: 3,
-            slidesPerGroup: 1,
-          },
-          1440: {
-            slidesPerView: 5,
-            slidesPerGroup: 1,
-          },
-        },
-      }
-    },
-
     coloring() {
       return (this.color) ? `swiper--${this.color}` : null;
     }
   },
+
+  mounted() {
+    console.log(this.option);
+  }
 }
 </script>
 

--- a/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="slider">
-    <swiper :options="params">
+    <swiper :options="params" :class="coloring">
       <swiper-slide v-for="(player, n) in players" :key="n">
         <player-card :player="player">
           <template v-slot:addCardContents="player" v-if="player.category === activeAlumniNum">
@@ -11,9 +11,10 @@
         </player-card>
       </swiper-slide>
 
-      <!-- <div class="swiper-pagination" slot="pagination"></div> -->
-      <!-- <div class="swiper-button swiper-button-prev" slot="button-prev"></div>
-      <div class="swiper-button swiper-button-next" slot="button-next"></div> -->
+      <!-- swiper components -->
+      <div class="swiper-button swiper-button-prev" slot="button-prev"/>
+      <div class="swiper-button swiper-button-next" slot="button-next"/>
+      <div class="swiper-pagination" slot="pagination"/>
     </swiper>
   </div>
 </template>
@@ -30,18 +31,33 @@ export default {
   props: {
     // playerCardに受け渡す選手データ
     players: Array,
+
+    color: {
+      type: String,
+      default: '',
+    },
   },
 
   computed: {
     params() {
       return {
         loop: true, // ループ
-        speed: 1500,  // スライドする時間
-        // effect: "coverflow",  // スライドタイプ
+        speed: 1000,  // スライドする時間
         autoHeight: true,
 
         autoplay: {
           delay: 2500,
+        },
+
+        navigation: {
+          nextEl: '.swiper-button-next',
+          prevEl: '.swiper-button-prev',
+        },
+
+        pagination: {
+          el: '.swiper-pagination',
+          clickable: false,
+          type: 'bullets',
         },
 
         breakpoints: {
@@ -58,20 +74,11 @@ export default {
             slidesPerGroup: 1,
           },
         },
-
-        // ナビゲーション
-        navigation: {
-          nextEl: '.c-imageSlider .swiper-button-next',
-          prevEl: '.c-imageSlider .swiper-button-prev',
-        },
-
-        // ページネーション
-        pagination: {
-          el: '.c-imageSlider .swiper-pagination',
-          clickable: true,
-          type: 'progressbar',
-        },
       }
+    },
+
+    coloring() {
+      return (this.color) ? `swiper--${this.color}` : null;
     }
   },
 }
@@ -91,6 +98,18 @@ export default {
     }
   }
 
+  .swiper {
+    @include swiper-pagination(color(white), interval(3));
+    @include swiper-button();
+  }
+
+  // swiper modifier
+  .swiper--darkblue {
+    .swiper {
+      @include swiper-pagination();
+      @include swiper-button(color(lightDarkblue));
+    }
+  }
 }
 
 // slotで差し込んだ部分のスタイル

--- a/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
+++ b/src/resources/js/components/modules/slider/PlayerSliderComponent.vue
@@ -65,12 +65,12 @@ export default {
             slidesPerView: 2,
             slidesPerGroup: 2,
           },
-          800: {
+          860: {
             slidesPerView: 3,
             slidesPerGroup: 1,
           },
           1440: {
-            slidesPerView: 4,
+            slidesPerView: 5,
             slidesPerGroup: 1,
           },
         },

--- a/src/resources/js/views/Club.vue
+++ b/src/resources/js/views/Club.vue
@@ -206,15 +206,23 @@ export default {
  */
 const mainVisualApiResponse = [
   {
+    id      : 1,
     src     : 'player41.jpg',
     alt     : 'altテキストを入れます',
     caption : '感謝と謙虚な心を忘れずに、日本一。',
   },
   {
+    id      : 2,
     src     : 'training01.jpg',
     alt     : 'altテキストを入れます',
     caption : 'テキストは AMAZON EC2 を使用します。',
-  }
+  },
+  {
+    id      : 3,
+    src     : 'player43.jpg',
+    alt     : 'altテキストを入れます',
+    caption : 'テキストは AMAZON EC2 を使用します。',
+  },
 ];
 
 /**

--- a/src/resources/js/views/Hakumonkai.vue
+++ b/src/resources/js/views/Hakumonkai.vue
@@ -19,7 +19,7 @@
   <section class="hakumonkai__active" v-fade:[dir.up]>
     <contents-title :title="messages.SectionTitles.ActiveAlumni"/>
 
-    <player-slider :players="activeAlumni" color="darkblue"/>
+    <player-slider :players="activeAlumni" color="darkblue" :option="swiperOptions"/>
   </section>
 
   <section class="hakumonkai__message" v-fade:[dir.up]>
@@ -75,6 +75,7 @@ export default {
       activeAlumni: [],
     }
   },
+
   beforeMount() {
     // 役員テーブルの [見出し] 配列を取得
     this.$data.messages.Hakumonkai.OfficerTable.Heading.forEach(element => this.tableHeading.push(element));
@@ -88,6 +89,42 @@ export default {
     this.$data.data.Users.forEach(element => {
       (element.category === this.activeAlumniNum) ? this.activeAlumni.push(element) : null;
     });
+  },
+
+  computed: {
+    swiperOptions() {
+      return {
+        loop: true,
+        speed: 1000,
+        autoHeight: true,
+
+        autoplay: {
+          delay: 2500,
+        },
+
+        navigation: {
+          nextEl: '.swiper-button-next',
+          prevEl: '.swiper-button-prev',
+        },
+
+        pagination: {
+          el: '.swiper-pagination',
+          clickable: true,
+          type: 'bullets',
+        },
+
+        breakpoints: {
+          560: {
+            slidesPerView: 2,
+            slidesPerGroup: 1,
+          },
+          860: {
+            slidesPerView: 3,
+            slidesPerGroup: 1,
+          }
+        },
+      }
+    }
   },
 }
 </script>

--- a/src/resources/js/views/Hakumonkai.vue
+++ b/src/resources/js/views/Hakumonkai.vue
@@ -19,7 +19,7 @@
   <section class="hakumonkai__active" v-fade:[dir.up]>
     <contents-title :title="messages.SectionTitles.ActiveAlumni"/>
 
-    <player-slider :players="activeAlumni"/>
+    <player-slider :players="activeAlumni" color="darkblue"/>
   </section>
 
   <section class="hakumonkai__message" v-fade:[dir.up]>

--- a/src/resources/sass/_mixin.scss
+++ b/src/resources/sass/_mixin.scss
@@ -285,3 +285,73 @@
     @include gradient($start-color, $end-color, $direction);
   }
 }
+
+/**
+ * swiper
+ */
+
+// next/prev button
+@mixin swiper-button($color: color(lightgray), $size: interval(6)) {
+  &-button-next,
+  &-button-prev {
+    width: $size;
+    height: $size;
+    border: 1px solid $color;
+    border-radius: radius(circle);
+    outline: none;
+    transform: translateY(- interval(2));
+
+    &::after {
+      content: '';
+    }
+  }
+
+  &-button-next {
+    right: interval(.5);
+
+    @if $color == color(lightDarkblue) {
+      @include background-image('data:image/svg+xml;utf8,#{$arrow-right-darkblue}', center center, calc(#{$size} / 2));
+    }
+    @else if $color == color(lightgray) {
+      @include background-image('data:image/svg+xml;utf8,#{$arrow-right}', center center, calc(#{$size} / 2));
+    }
+  }
+
+  &-button-prev {
+    left: interval(.5);
+
+    @if $color == color(lightDarkblue) {
+      @include background-image('data:image/svg+xml;utf8,#{$arrow-left-darkblue}', center center, calc(#{$size} / 2));
+    }
+    @else if $color == color(lightgray) {
+      @include background-image('data:image/svg+xml;utf8,#{$arrow-left}', center center, calc(#{$size} / 2));
+    }
+  }
+}
+
+// pagination
+@mixin swiper-pagination($color: color(lightDarkblue), $size: interval(5)) {
+  &-container {
+    padding-bottom: interval(3);
+  }
+
+  &-pagination-bullets {
+    bottom: 0;
+
+    // ページネーションの丸は、スロットで読まれるためディープセレクタにする
+    &::v-deep .swiper-pagination-bullet {
+      opacity: 1;
+      position: relative;
+      width: $size;
+      height: 3px;
+      border-radius: 0;
+      margin: 0 interval(.5);
+      transition: background-color .3s ease;
+      background-color: rgba($color, .2);
+    }
+
+    &::v-deep .swiper-pagination-bullet-active {
+      background-color: $color;
+    }
+  }
+}

--- a/src/resources/sass/_modules.scss
+++ b/src/resources/sass/_modules.scss
@@ -57,6 +57,10 @@
  */
 $angle-down: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="5 5 14 14" fill="%2310334e"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/></svg>';
 
+$arrow-right: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 3 18 18"><path d="M0 0h24v24H0z" fill="none"/><path fill="%23f2f2f2" d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"/></svg>';
+
+$arrow-left: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 3 18 18"><path d="M0 0h24v24H0z" fill="none"/><path fill="%23f2f2f2" d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>';
+
 /**
  * @keyframes
  */
@@ -173,5 +177,11 @@ $angle-down: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="5 5 14 14" fill="
   }
   100%{
     height: 0;
+  }
+}
+
+@keyframes gauge {
+  100% {
+    transform: scaleX(1);
   }
 }

--- a/src/resources/sass/_modules.scss
+++ b/src/resources/sass/_modules.scss
@@ -61,6 +61,11 @@ $arrow-right: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 3 18 18"><path
 
 $arrow-left: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 3 18 18"><path d="M0 0h24v24H0z" fill="none"/><path fill="%23f2f2f2" d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>';
 
+
+$arrow-right-darkblue: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 3 18 18"><path d="M0 0h24v24H0z" fill="none"/><path fill="%2310334e" d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"/></svg>';
+
+$arrow-left-darkblue: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 3 18 18"><path d="M0 0h24v24H0z" fill="none"/><path fill="%2310334e" d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>';
+
 /**
  * @keyframes
  */


### PR DESCRIPTION
## 概要

- ナビゲーションとページネーションのレイアウトはできるだけ共通のものを使うので、スタイルをmixinに記述。
- ボタンの背景にsvg（矢印）を指定するために、svgをcss変数に格納。（module.scss ）
- イメージデータにID付与。

### メインビジュアルスライダーのレイアウトを修正。

- デザインに沿ってスライダーページネーションを実装。
- ゲージアニメーションは試みたが、複雑になりそうなので未実装。（時間かければできそう）
- オプション調整

### imageSliderのレイアウトを修正
使用箇所：コートの写真と寮の部屋写真

- ナビゲーションとページネーションを実装。
- オプション調整

### playerSliderのレイアウト修正
使用箇所：/club メンバーセクション、/hakumonkai 活躍中OBセクション

- ナビゲーションとページネーションを実装。
- オプションを呼び出し元から指定できるように修正。（props登録）
- 背景によってボタンの色やページネーションの色を指定できるように実装