### PR TITLE
/club 写真セクションのモーダルバグを修正

### DIFF
--- a/src/resources/js/components/contents/ArrangeImagesComponent.vue
+++ b/src/resources/js/components/contents/ArrangeImagesComponent.vue
@@ -125,8 +125,12 @@ export default {
   }
 
   &__list-item {
-    width: interval(32);
-    padding: interval(.5);
+    border: 1px solid color(lightgray);
+    width: interval(18);
+
+    @include mq(md) {
+      width: interval(20);
+    }
   }
 
   &__image {

--- a/src/resources/js/components/contents/ImagesListComponent.vue
+++ b/src/resources/js/components/contents/ImagesListComponent.vue
@@ -1,9 +1,9 @@
 <template>
-<div class="arrange-images">
-  <ul class="arrange-images__list">
-    <li class="arrange-images__list-item" ref="item" v-for="(image, n) in filterImages" :key="n">
+<div class="images-list">
+  <ul class="images-list__list">
+    <li class="images-list__item" ref="item" v-for="(image, n) in filterImages" :key="n">
       <!-- img要素をクリックしたらモーダルで拡大表示する -->
-      <figure class="arrange-images__image" @click="openModal(image)">
+      <figure class="images-list__image" @click="openModal(image)">
         <img :src="`/image/${image.src}`" :alt="image.alt">
       </figure>
     </li>
@@ -20,7 +20,7 @@
   <image-modal
     v-if="showModal"
     @close="closeModal"
-    :selectIndex="selectImageIndex"
+    :selectIndex="selectIndex"
     :images="filterImages"/>
 </div>
 </template>
@@ -63,7 +63,7 @@ export default {
        * [選択した画像のインデックス番号]
        * @type { Number }
        */
-      selectImageIndex: 0,
+      selectIndex: 0,
     }
   },
 
@@ -104,7 +104,7 @@ export default {
     openModal(el) {
       this.showModal = true;
 
-      this.selectImageIndex = this.filterImages.indexOf(el);
+      this.selectIndex = this.filterImages.indexOf(el);
       document.body.classList.add("modal-open");
     },
     closeModal() {
@@ -118,13 +118,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.arrange-images {
+.images-list {
 
   &__list {
     @include flex(row wrap, center, center);
   }
 
-  &__list-item {
+  &__item {
     border: 1px solid color(lightgray);
     width: interval(18);
 

--- a/src/resources/js/views/Club.vue
+++ b/src/resources/js/views/Club.vue
@@ -91,7 +91,6 @@
   <div class="background-darkblue">
     <section class="club__member" v-fade:[dir.up]>
       <contents-title :title="messages.SectionTitles.Member" color="white"/>
-
       <player-slider :players="players"/>
 
       <div class="member__number">
@@ -108,10 +107,9 @@
     </section>
   </div>
 
-  <section class="club__photo" v-fade:[dir.up]>
+  <section class="club__photo">
     <contents-title :title="messages.SectionTitles.Photo"/>
-
-    <arrange-images :images="images"/>
+    <images-list :images="images"/>
 
     <div class="photo__button">
       <link-button :link="messages.Links.Photo"/>
@@ -142,7 +140,7 @@ import CaptionImage from '../components/modules/CaptionImageComponent';
 import DormitoryTicket from '../components/modules/ticket/DormitoryTicketComponent';
 import PlayerSlider from '../components/modules/slider/PlayerSliderComponent';
 import LinkButton from '../components/modules/button/LinkButtonComponent';
-import ArrangeImages from '../components/contents/ArrangeImagesComponent';
+import ImagesList from '../components/contents/ImagesListComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent'
 
 export default {
@@ -157,7 +155,7 @@ export default {
     DormitoryTicket,
     PlayerSlider,
     LinkButton,
-    ArrangeImages,
+    ImagesList,
     ScrollTopButton,
   },
 

--- a/src/resources/js/views/Club.vue
+++ b/src/resources/js/views/Club.vue
@@ -107,7 +107,7 @@
     </section>
   </div>
 
-  <section class="club__photo">
+  <section class="club__photo fade" v-scroll="fade">
     <contents-title :title="messages.SectionTitles.Photo"/>
     <images-list :images="images"/>
 


### PR DESCRIPTION
## 概要
/clubの写真セクションで、モーダルが画面いっぱいに表示されないバグを修正。
原因は、v-fadeディレクティブでtransitionをいじっていることが原因だと考えられる。

### モーダルのバグを除去するため、アニメーションを削除
写真セクションにv-fadeディレクティブを与えないことでひとまずバグは起きない。
リリース後にアニメーションしてもモーダルが正常に表示できるように改修する。

### 写真のwidthを見直し
写真サイズが大きい気がしたので、少し小さめに設定。
320px幅でも最低2列になるように修正。