### PR TITLE
TwitterAPIの処理をまとめたファイルを使ってレスポンスを取得する。

### DIFF
--- a/src/app/Http/Controllers/Api/TwitterApiController.php
+++ b/src/app/Http/Controllers/Api/TwitterApiController.php
@@ -39,15 +39,16 @@ class TwitterApiController extends Controller
       )
     );
 
-    // 現在日時取得のため、CarbonControllerからメソッドを呼ぶ
+    // APIにデータを追加するために扱う変数を定義。
     $current_date = CarbonController::getCurrentDate('Y-m');
-    $base_uri = config('constants.twitter.base_uri');
+    $base_link_uri = config('constants.twitter.base_uri');
 
     foreach ($response as $index => $value) {
       $created_date = date('Y-m', strtotime((string) $value->created_at));
+      $screen_name = $value->user->screen_name;
 
-      $value->link = $base_uri . $value->id_str;
       $value->created_date = $created_date;
+      $value->link = $base_link_uri . $screen_name . '/status/' . $value->id_str;
       $value->new = ($created_date === $current_date) ? true : false;
     };
 

--- a/src/app/Http/Controllers/CarbonController.php
+++ b/src/app/Http/Controllers/CarbonController.php
@@ -9,20 +9,12 @@ class CarbonController extends Controller
 {
   /**
    * 現在日付取得
+   * @param string format
    */
-  public function getCurrentDate()
+  public static function getCurrentDate($format)
   {
     // dateインスタンス
     $date = Carbon::now('Asia/Tokyo');
-    $separate_date = explode('-', $date->toDateString());
-
-    // 扱いやすい配列に整形
-    $current_date = array(
-      'year'  => $separate_date[0],
-      'month' => $separate_date[1],
-      'date'  => $separate_date[2],
-    );
-
-    return $current_date;
+    return $date->format($format);
   }
 }

--- a/src/resources/js/components/contents/NewsComponent.vue
+++ b/src/resources/js/components/contents/NewsComponent.vue
@@ -3,35 +3,34 @@
 
   <contents-title :title="messages.SectionTitles.News"/>
 
+  <!-- ローディング画面 -->
   <div class="news__loading" v-if="loading">
-    <!-- <transition-group name="load" tag="div"> -->
       <div class="loading">
         <div class="loading__obj" v-for="i in 8" :key="i"/>
       </div>
-    <!-- </transition-group> -->
   </div>
 
+  <!-- ニュースリスト -->
   <div class="news__wrap" v-else>
-    <!-- ニュースリスト -->
-    <ul class="news__list" v-if="!showErr">
-      <li class="news__item" v-for="(tweet, i) in tweets" :key="i">
-        <a class="news__link" :href="linkUrl + tweet.id_str" target="_blank" rel="noopener noreferrer">
+    <ul class="news__list" v-if="!twitter.err">
+      <li class="news__item" v-for="(tweet, i) in twitter.timelines" :key="i">
+        <a class="news__link" :href="tweet.link" target="_blank" rel="noopener noreferrer">
           {{ tweet.text }}
         </a>
 
         <!-- NEW ラベル -->
-        <span class="news__latest-label" v-if="showLatest && (i === 0)">
+        <span class="news__latest-label" v-if="tweet.new">
           {{ messages.Label.Latest }}
         </span>
       </li>
     </ul>
 
     <!-- エラー画面 -->
-    <div class="err" v-if="showErr">
+    <div class="err" v-if="twitter.err">
       <span class="err__text">{{ messages.Error.Api.News }}</span>
 
       <div class="err__btn">
-        <primary-button :btn="messages.Button.NewsRequest" @clickEvent="getResponse"/>
+        <primary-button :btn="messages.Button.NewsRequest" @clickEvent="reload"/>
       </div>
     </div>
   </div>
@@ -44,8 +43,7 @@
 import ContentsTitle from '../modules/ContentsTitleComponent';
 import PrimaryButton from '../modules/button/PrimaryButtonComponent.vue';
 
-// Library import
-import axios from 'axios';
+import Twitter from '../../config/api/twitter/index';
 
 export default {
   components: {
@@ -55,104 +53,36 @@ export default {
 
   data() {
     return {
-      /**
-       * ニュース押下後に遷移するリンクURL
-       * @type { string }
-       */
-      linkUrl: '',
-
-      /**
-       * twitter APIから取得した情報を格納
-       * 非同期処理でデータを取得しているため、コンソールで確認ができないことに注意。
-       * @type { Array }
-       */
-      tweets: null,
-
-      /**
-       * 1ヶ月以内の投稿に「NEW」を表示するためのフラグ。
-       * @type { Boolean }
-       */
-      showLatest: false,
-
-      /**
-       * ツイートが取得できなかった場合に表示
-       * @type { Boolean }
-       */
-      showErr: false,
-
-      /**
-       * ロード判定
-       * @type { Boolean }
-       */
-      loading: false,
+      twitter: {
+        timelines: null,
+        err: false,
+        loading: true,
+      },
     }
   },
 
-  beforeMount() {
-    // サーバーからツイートデータを取得
-    this.getResponse();
+  computed: {
+    loading() {
+      return (this.twitter.timelines) ? false : true;
+    }
+  },
 
-    /**
-     * [リンクURL]
-     * 下記URLにツイートのIDを付与することでリンクURLを生成する。
-     */
-    this.linkUrl = 'https://twitter.com/SoftTennis_Chuo/status/';
+  created() {
+    this.getTweets();
   },
 
   methods: {
-    /**
-     * サーバーからtwitter APIレスポンスを取得。
-     */
-    async getResponse() {
-      // ロード開始
-      this.loading = true;
+    async getTweets() {
+      const tweets = await Twitter.getResponse('/api/twitter/timeline');
 
-      await this.$axios.get('/api/twitter/timeline')
-
-      .then(function (response) {
-        // 返答がオブジェクト形式ではない場合にエラー画面を出す。
-        if (typeof response.data !== 'object') {
-          console.log(response.data);
-          return this.err();
-        }
-
-        // apiレスポンスを変数に格納。(直近のツイート3件)
-        this.tweets = response.data;
-
-        // 投稿日と現在の日付を比較して、ラベルを表示させる。
-        const createdYear = this.tweets[0].created_date.year;    // 投稿年
-        const createdMonth = this.tweets[0].created_date.month;  // 投稿月
-        const currentYear = this.tweets[0].current_date.year;    // 現在の年
-        const currentMonth = this.tweets[0].current_date.month;  // 現在の月
-
-        if ((createdYear === currentYear) && (createdMonth === currentMonth)) this.showLatest = true;
-
-        this.showErr = false;
-      }.bind(this))
-
-      .catch(function (err) {
-        console.log(err);
-
-        if (err.response) {
-          console.log('Err Message:', err.response.data.message);
-          console.log('Status Code:', err.response.status);
-          console.log('Status Text:', err.response.statusText);
-        }
-
-        // エラー画面出力。
-        this.err();
-      }.bind(this))
-
-      // 成功でもエラーでも通信後に共通の処理
-      .finally(function () {
-        this.loading = false;
-      }.bind(this))
+      if (this.getType(tweets) === 'array') {
+        this.twitter.timelines = tweets;
+      }
+      else {
+        this.twitter.timelines = {};
+        this.twitter.err = true;
+      }
     },
-
-    err() {
-      this.showErr = true;
-      this.tweets = null;
-    }
   }
 }
 </script>
@@ -175,7 +105,7 @@ export default {
 
   &__item {
     font-size: font(12);
-    margin-bottom: interval(1);
+    margin-bottom: interval(1.5);
     word-wrap: break-word;
     position: relative;
 

--- a/src/resources/js/components/modules/modal/NavModalComponent.vue
+++ b/src/resources/js/components/modules/modal/NavModalComponent.vue
@@ -96,7 +96,9 @@ export default {
      */
     snsPanels() {
       let snsPanels = [];
-      snsPanels.push(this.twitter);
+      if (this.twitter) {
+        snsPanels.push(this.twitter);
+      }
       return snsPanels;
     }
   },

--- a/src/resources/js/config/api/twitter/index.js
+++ b/src/resources/js/config/api/twitter/index.js
@@ -1,13 +1,11 @@
 import axios from 'axios';
-import config from '../../config.json';
-import global from '../../global';
 
 /**
  * 環境判定  @type { Boolean }
- * [本番]false
- * [開発]true
+ * [本番]:false
+ * [開発]:true
  */
-const debug = !process.env.MIX_PRODUCTION;
+const debug = !process.env.PRODUCTION;
 
 export default {
   async getResponse(url) {
@@ -19,9 +17,9 @@ export default {
       })
 
       .catch(function (err) {
+        console.log(err.message);
         if (debug) {
           console.log(err);
-          console.log(`エラーメッセージ：${err.message}`);
           console.log(err.response);
         }
         // TODO:エラーページへリダイレクト

--- a/src/resources/js/config/global.js
+++ b/src/resources/js/config/global.js
@@ -35,5 +35,15 @@ export default {
     getType(target) {
       return toString.call(target).slice(8, -1).toLowerCase();
     },
+
+    /**
+     * 現在のページをリロード
+     */
+    reload() {
+      this.$router.go({
+        path: this.$router.currentRoute.path,
+        force: true,
+      })
+    }
   },
 }


### PR DESCRIPTION
## 概要

- ニュースの取得（Twitterタイムライン）を外部JSファイルを使用して取得する。
- タイムライン取得処理の中にフロントで使用するデータを挿入。（フォーマットしたcreated_atなど。）
- APIのタイムアウト時にナビが展開できなくなる不具合が発覚したので、修正。

