### PR TITLE
Twitter APIのレスポンスを使用してチケットとモーダルを表示させる。

### DIFF
--- a/src/app/Http/Controllers/Api/TwitterApiController.php
+++ b/src/app/Http/Controllers/Api/TwitterApiController.php
@@ -82,13 +82,16 @@ class TwitterApiController extends Controller
   {
     $providers = config('constants.twitter.providers');
     $provider_ids = array_values($providers);
+    $base_link_uri = config('constants.twitter.base_uri');
 
     $params = [
       'user_id' => $provider_ids
     ];
     $response = $this->connection()->get('users/lookup', $params);
-    json_encode($response);
+    foreach ($response as $index => $value) {
+      $value->link = $base_link_uri . $value->screen_name;
+    }
 
-    return $response;
+    return response()->json($response);
   }
 }

--- a/src/app/Http/Controllers/Api/TwitterApiController.php
+++ b/src/app/Http/Controllers/Api/TwitterApiController.php
@@ -88,8 +88,9 @@ class TwitterApiController extends Controller
       'user_id' => $provider_ids
     ];
     $response = $this->connection()->get('users/lookup', $params);
-    foreach ($response as $index => $value) {
-      $value->link = $base_link_uri . $value->screen_name;
+    foreach ($response as $index => $val) {
+      $val->link = $base_link_uri . $val->screen_name;
+      $val->profile_image_url_original = str_replace('_normal', '', $val->profile_image_url);
     }
 
     return response()->json($response);

--- a/src/resources/js/components/modules/modal/ProviderModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ProviderModalComponent.vue
@@ -7,13 +7,13 @@
 
             <div class="provider-modal__thumbnail">
               <figure class="provider-modal__image">
-                <!-- <img :src="item.profile_image_url" :alt="`${item.name}のプロフィール画像`"> -->
+                <img :src="item.profile_image_url_original" :alt="`${item.name}のプロフィール画像`">
               </figure>
             </div>
 
             <div class="provider-modal__info">
               <div class="provider-modal__name">
-                <!-- <h4 class="provider-modal__name-main">{{ item.name }}</h4> -->
+                <h4 class="provider-modal__name-main">{{ item.name }}</h4>
               </div>
             </div>
           </header>
@@ -49,10 +49,6 @@ export default {
       type: Object,
       default: null,
     },
-  },
-
-  computed: {
-
   },
 
   beforeMount() {

--- a/src/resources/js/components/modules/modal/ProviderModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ProviderModalComponent.vue
@@ -52,7 +52,7 @@ export default {
   },
 
   beforeMount() {
-    console.log(this.item);
+    // console.log(this.item);
   },
 
   methods: {

--- a/src/resources/js/components/modules/modal/ProviderModalComponent.vue
+++ b/src/resources/js/components/modules/modal/ProviderModalComponent.vue
@@ -1,0 +1,148 @@
+<template>
+  <modal @close="close">
+    <template v-slot:content>
+      <div class="provider-modal">
+        <div class="provider-modal__container">
+          <header class="provider-modal__header">
+
+            <div class="provider-modal__thumbnail">
+              <figure class="provider-modal__image">
+                <!-- <img :src="item.profile_image_url" :alt="`${item.name}のプロフィール画像`"> -->
+              </figure>
+            </div>
+
+            <div class="provider-modal__info">
+              <div class="provider-modal__name">
+                <!-- <h4 class="provider-modal__name-main">{{ item.name }}</h4> -->
+              </div>
+            </div>
+          </header>
+
+          <div class="provider-modal__line"/>
+
+          <div class="provider-modal__contents">
+
+          </div>
+
+        </div>
+      </div>
+    </template>
+  </modal>
+</template>
+
+<script>
+// component import
+import Modal from '../modal/ModalComponent';
+import TableComponent from '../table/TableComponent.vue';
+
+export default {
+  components: {
+    Modal,
+    TableComponent,
+  },
+
+  props: {
+    /**
+     * [クリックしたチケットのデータ]
+     */
+    item: {
+      type: Object,
+      default: null,
+    },
+  },
+
+  computed: {
+
+  },
+
+  beforeMount() {
+    console.log(this.item);
+  },
+
+  methods: {
+    close() {
+      this.$emit('close');
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.provider-modal {
+  background-color: color(white);
+  width: 100%;
+  margin: interval(5) auto;
+  border-radius: radius(hard);
+  position: relative;
+
+  @include mq(sm) {
+    width: 80%;
+  }
+
+  &__container {
+    padding: interval(2);
+
+    @include mq(md) {
+      padding: interval(3)
+    }
+  }
+
+  &__header {
+    @include flex(column nowrap, center, center);
+    padding: interval(5) 0;
+
+    @include mq(sm) {
+      @include flex(row nowrap, center, center);
+    }
+  }
+
+  &__info {
+    margin-top: interval(3);
+
+    @include mq(sm) {
+      margin-top: 0;
+      margin-left: interval(3);
+    }
+  }
+
+  &__thumbnail {
+    width: interval(20);
+    @include thumbnail-border();
+
+    @include mq(sm) {
+      width: interval(18);
+    }
+  }
+
+  &__image {
+    @include trimming(aspect(square));
+    width: 100%;
+
+    & > img {
+      border-radius: radius(circle);
+    }
+  }
+
+  &__name {
+    text-align: center;
+
+    @include mq(sm) {
+      text-align: left;
+    }
+  }
+
+  &__name-sub {
+    font-size: font(14);
+  }
+
+  &__name-main {
+    font-size: font(18);
+  }
+
+  &__line {
+    width: 100%;
+    height: 2px;
+    background-color: color(lightgray);
+  }
+}
+</style>

--- a/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
@@ -1,25 +1,27 @@
 <template>
 <div class="provider-ticket" ref="targetElement" @click="openModal">
-  <div class="provider-ticket-thumbnail-border">
-    <figure class="provider-ticket-thumbnail">
-      <img :src="provider.profile_image_url_original" :alt="`${provider.name}のプロフィール画像`">
-    </figure>
-  </div>
-
-  <div class="provider-ticket-item">
-    <span class="provider-ticket__name">{{ provider.name }}</span>
-
-    <!-- SNSタグは 2つ まで -->
-    <div class="provider-ticket-tag-group">
-      <!-- twitter -->
-      <sns-tag sns="twitter" content="Twitter"/>
-      <!-- instagram -->
-      <sns-tag sns="instagram" content="Instagram"/>
+  <div class="provider-ticket__ticket">
+    <div class="provider-ticket-thumbnail-border">
+      <figure class="provider-ticket-thumbnail">
+        <img :src="provider.profile_image_url_original" :alt="`${provider.name}のプロフィール画像`">
+      </figure>
     </div>
-  </div>
 
-  <div class="provider-ticket-item">
-    <svg-vue class="provider-ticket-icon" icon="angle_right"/>
+    <div class="provider-ticket-item">
+      <span class="provider-ticket__name">{{ provider.name }}</span>
+
+      <!-- SNSタグは 2つ まで -->
+      <div class="provider-ticket-tag-group">
+        <!-- twitter -->
+        <sns-tag sns="twitter" content="Twitter"/>
+        <!-- instagram -->
+        <sns-tag sns="instagram" content="Instagram"/>
+      </div>
+    </div>
+
+    <div class="provider-ticket-item">
+      <svg-vue class="provider-ticket-icon" icon="angle_right"/>
+    </div>
   </div>
 
   <!-- モーダル -->
@@ -73,27 +75,26 @@ export default {
 
 <style lang="scss">
 .provider-ticket {
-  @include flex(row nowrap, space-between, center);
-  box-shadow: 0 3px 5px 3px color(darkShadow);
-  background-color: color(white);
-  border: 2px solid color(light);
-  border-radius: 100px;
-  padding: interval(1);
-  position: relative;
   width: interval(34);
 
   @include mq(md) {
     cursor: pointer;
-    box-shadow: 0 1px 3px 1px color(darkShadow);
-    transition: all .3s ease-out;
   }
 
-  @include hover {
+  &__ticket {
+    @include flex(row nowrap, space-between, center);
+    padding: interval(1);
     box-shadow: 0 3px 5px 3px color(darkShadow);
-    transform: translateY(-2px);
+    border-radius: 100px;
 
-    .provider-ticket-icon {
-      animation: iconSlide 1.5s infinite;
+    @include mq(md) {
+      box-shadow: 0 1px 3px 1px color(darkShadow);
+      transition: all .3s ease-out;
+    }
+
+    @include hover {
+      box-shadow: 0 3px 5px 3px color(darkShadow);
+      transform: translateY(-2px);
     }
   }
 

--- a/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
@@ -1,13 +1,13 @@
 <template>
-<div class="provider-ticket" ref="targetElement">
+<div class="provider-ticket" ref="targetElement" @click="openModal">
   <div class="provider-ticket-thumbnail-border">
     <figure class="provider-ticket-thumbnail">
-      <img :src="`/image/${providerObj.img.src}`" alt="userObj.img.alt">
+      <img :src="provider.profile_image_url_original" :alt="`${provider.name}のプロフィール画像`">
     </figure>
   </div>
 
   <div class="provider-ticket-item">
-    <span class="provider-ticket__name">{{ providerObj.name.ja }}</span>
+    <span class="provider-ticket__name">{{ provider.name }}</span>
 
     <!-- SNSタグは 2つ まで -->
     <div class="provider-ticket-tag-group">
@@ -22,27 +22,51 @@
     <svg-vue class="provider-ticket-icon" icon="angle_right"/>
   </div>
 
+  <!-- モーダル -->
+  <provider-modal v-if="isShow" :item="provider"/>
 </div>
 </template>
 
 <script>
 // component import
 import SnsTag from '../tag/SnsTagComponent';
+import ProviderModal from '../modal/ProviderModalComponent';
 
 export default {
   components: {
     SnsTag,
+    ProviderModal,
+  },
+
+  data() {
+    return {
+      /**
+       * モーダルの開閉判定フラグ
+       * @type { Boolean }
+       */
+      isShow: false,
+    }
   },
 
   props: {
-    providerObj: {
+    provider: {
       type: Object,
       default: null
     }
   },
 
-  computed: {
-
+  methods: {
+    /**
+     * [モーダル開閉処理]
+     */
+    openModal() {
+      this.isShow = true;
+      document.body.classList.add("modal-open");
+    },
+    closeModal() {
+      this.isShow = false;
+      document.body.classList.remove("modal-open");
+    },
   },
 }
 </script>

--- a/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
@@ -1,6 +1,6 @@
 <template>
-<div class="provider-ticket" ref="targetElement" @click="openModal">
-  <div class="provider-ticket__ticket">
+<div class="provider-ticket" ref="targetElement">
+  <div class="provider-ticket__ticket" @click="openModal">
     <div class="provider-ticket-thumbnail-border">
       <figure class="provider-ticket-thumbnail">
         <img :src="provider.profile_image_url_original" :alt="`${provider.name}のプロフィール画像`">
@@ -12,9 +12,7 @@
 
       <!-- SNSタグは 2つ まで -->
       <div class="provider-ticket-tag-group">
-        <!-- twitter -->
         <sns-tag sns="twitter" content="Twitter"/>
-        <!-- instagram -->
         <sns-tag sns="instagram" content="Instagram"/>
       </div>
     </div>
@@ -25,7 +23,7 @@
   </div>
 
   <!-- モーダル -->
-  <provider-modal v-if="isShow" :item="provider"/>
+  <provider-modal v-if="isShow" :item="provider" @close="closeModal"/>
 </div>
 </template>
 

--- a/src/resources/js/views/Photo.vue
+++ b/src/resources/js/views/Photo.vue
@@ -25,14 +25,8 @@
     </div>
 
     <!-- モーダル -->
-    <user-modal v-if="modal.show" @close="closeModal" :item="modal.element">
-      <template v-slot:content>
-        <div class="provider">
-          <!-- TODO:ここに出すコンテンツを考える。 -->
-          ここに出すコンテンツを考える。
-        </div>
-      </template>
-    </user-modal>
+    <provider-modal v-if="modal.show" :item="modal.element"/>
+
   </section>
 
   <div class="photo__scroll-top">
@@ -54,14 +48,14 @@ import Animation from '../config/animation';
 import ContentsTitle from '../components/modules/ContentsTitleComponent';
 import Images from '../components/contents/ImagesComponent';
 import ProviderTicket from '../components/modules/ticket/ProviderTicketComponent';
-import UserModal from '../components/modules/modal/UserModalComponent';
+import ProviderModal from '../components/modules/modal/ProviderModalComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
     ContentsTitle,
     Images,
-    UserModal,
+    ProviderModal,
     ProviderTicket,
     ScrollTopButton,
   },
@@ -121,15 +115,16 @@ export default {
     }
   },
 
+  created() {
+    this.getProvider();
+  },
+
   beforeMount() {
     this.$data.data.ImageApiResponse.forEach(element => this.images.push(element));
     this.$data.data.Provider.forEach(element => this.providers.push(element));
   },
 
   mounted() {
-    // Api叩く
-    this.getProvider();
-
     /**
      * [チケットの配置を左揃えするための処理]
      */
@@ -164,6 +159,7 @@ export default {
     // Twitter Apiからデータを取得
     async getProvider() {
       const response = await Twitter.getResponse('/api/twitter/provider');
+      console.log(response);
 
       // 予期しない型が返却された場合
       if (!response || !Array.isArray(response.data)) {

--- a/src/resources/js/views/Photo.vue
+++ b/src/resources/js/views/Photo.vue
@@ -12,20 +12,18 @@
     <contents-title :title="messages.SectionTitles.Provider"/>
 
     <div class="ticket-group">
-      <div class="ticket" v-for="(provider, n) in providers" :key="n" ref="providerTicket" @click="openModal(provider)">
-        <provider-ticket :providerObj="provider"/>
+      <div class="ticket" v-for="(provider, n) in provider.response" :key="n" ref="providerTicket">
+        {{ provider.response }}
+        <provider-ticket :provider="provider"/>
       </div>
       <!-- 左寄せに並べたいので空の要素をチケット分追加 -->
       <div
-        class="enpty"
+        class="empty"
         v-for="n in ticket.number"
-        :key="`enpty-${n}`"
+        :key="`empty-${n}`"
         :style="{ width: `${ticket.width}px` }"
       />
     </div>
-
-    <!-- モーダル -->
-    <provider-modal v-if="modal.show" :item="modal.element"/>
 
   </section>
 
@@ -48,14 +46,12 @@ import Animation from '../config/animation';
 import ContentsTitle from '../components/modules/ContentsTitleComponent';
 import Images from '../components/contents/ImagesComponent';
 import ProviderTicket from '../components/modules/ticket/ProviderTicketComponent';
-import ProviderModal from '../components/modules/modal/ProviderModalComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 
 export default {
   components: {
     ContentsTitle,
     Images,
-    ProviderModal,
     ProviderTicket,
     ScrollTopButton,
   },
@@ -78,12 +74,6 @@ export default {
       images: [],
 
       /**
-       * [写真提供者の情報]
-       * @type { Array }
-       */
-      providers: [],
-
-      /**
        * [チケット]
        * width, 個数
        * @type { Number }
@@ -91,16 +81,6 @@ export default {
       ticket: {
         width: 0,
         number: 0,
-      },
-
-      /**
-       * modalデータ
-       * show: @type { Boolean }
-       * element: @type { Object }
-       */
-      modal: {
-        show: false,
-        element: null
       },
 
       /**
@@ -117,64 +97,56 @@ export default {
 
   created() {
     this.getProvider();
-  },
-
-  beforeMount() {
     this.$data.data.ImageApiResponse.forEach(element => this.images.push(element));
-    this.$data.data.Provider.forEach(element => this.providers.push(element));
   },
 
-  mounted() {
-    /**
-     * [チケットの配置を左揃えするための処理]
-     */
-    const ticket = this.$refs.providerTicket;
-    // チケットの要素数を取得 (チケットが一枚の時はenpty要素を増やさない)
-    if(ticket.length > 1) this.ticket.number = ticket.length;
-    this.getTicketWidth();
+  /**
+   * TODO:改修が必要。
+   * APIの返却値で構成しているチケットの幅が読み取れない。
+   * チケットは、APIが返却され次第レンダリングが実行されるので、幅や個数の初期値が設定できない。
+   * そもそもの配置（CSS）から考える必要がある。
+   */
+  updated() {
+    this.$nextTick(function () {
+      if (this.$refs.providerTicket !== undefined) {
+        this.setEmptyTicketData();
+      }
+    })
   },
 
   methods: {
     /**
-     * [チケットの幅を変数に格納]
-     * リサイズイベントに登録するため、メソッドにする。
+     * 空要素を生成するデータを格納。
+     * チケットの並びを左揃えにするために追加。
      */
-    getTicketWidth() {
-      this.ticket.width = this.$refs.providerTicket[0].offsetWidth;
-    },
-
-    /**
-     * [モーダル開閉処理]
-     */
-    openModal(el) {
-      this.modal.show = true;
-      this.modal.element = el;
-      document.body.classList.add("modal-open");
-    },
-    closeModal() {
-      this.modal.show = false;
-      document.body.classList.remove("modal-open");
+    setEmptyTicketData() {
+      const ticket = this.$refs.providerTicket;
+      if(ticket.length > 1) {
+        this.ticket.number = ticket.length;
+        this.ticket.width = this.$refs.providerTicket[0].offsetWidth;
+      }
     },
 
     // Twitter Apiからデータを取得
     async getProvider() {
       const response = await Twitter.getResponse('/api/twitter/provider');
-      console.log(response);
 
       // 予期しない型が返却された場合
-      if (!response || !Array.isArray(response.data)) {
+      if (!response || !Array.isArray(response)) {
         this.provider.err = true;
-        return
+        throw new Error('予期しないデータ型で返却されました。');
       }
-
-      this.provider.response = response.data;
+      this.provider.response = response;
     }
   },
 
   watch: {
     windowWidth() {
-      this.getTicketWidth();
-    }
+      if (this.ticket.width) {
+        console.log(this.ticket.width);
+        this.ticket.width = this.$refs.providerTicket[0].offsetWidth;
+      }
+    },
   },
 }
 


### PR DESCRIPTION
## 概要
### ・APIレスポンスを使用してproviderセクションのモーダルとチケットを表示させる。
### ・Twitterのオリジナルサイズのプロフィール画像をレスポンスに含める。
生のレスポンスに含まれているのは、画像サイズが小さくなった画像なので、オリジナルサイズをレスポンスに含める実装をコントローラーに追加。
### ・プロバイダーのモーダルコンポーネントを新規で追加。
データの構成がプロバイダーモーダルと選手スタッフモーダルでは違うのでコンポーネントを分ける。
### ・チケットコンポーネントの中でモーダルを呼び出し。
モーダルはチケットに紐づくコンポーネントなので、この修正をする。
加えて、チケットの中にモーダルコンポーネントを定義することでコードがわかりやすくなる。
ユーザーチケットにもこの修正を入れる。
### ・APIレスポンスでチケットを表示させるので、refsの取得周りを修正。
チケットを左寄せで並べるために追加していた空要素の生成でrefsを使用しているが、APIレスポンスを使うことでコードが複雑になる可能性があるのでレイアウトを考える。