### PR TITLE
チケットのレイアウト修正とコンポーネント細分化

### DIFF
--- a/src/app/Http/Controllers/Api/TwitterApiController.php
+++ b/src/app/Http/Controllers/Api/TwitterApiController.php
@@ -88,9 +88,17 @@ class TwitterApiController extends Controller
       'user_id' => $provider_ids
     ];
     $response = $this->connection()->get('users/lookup', $params);
+
+    // データ整形・作成
     foreach ($response as $index => $val) {
       $val->link = $base_link_uri . $val->screen_name;
-      $val->profile_image_url_original = str_replace('_normal', '', $val->profile_image_url);
+
+      $image_url = str_replace('_normal', '', $val->profile_image_url);
+      $images = (object) [
+        'src' => $image_url,
+        'alt' => $val->name . 'のプロフィール画像',
+      ];
+      $val->img = $images;
     }
 
     return response()->json($response);

--- a/src/resources/js/components/modules/UserThumbnailComponent.vue
+++ b/src/resources/js/components/modules/UserThumbnailComponent.vue
@@ -3,7 +3,7 @@
     <picture class="user-thumbnail__picture">
       <!-- <source v-if="image.source" :media="mq" :srcset="image.source.sp">
       <source v-if="image.source" :media="mq" :srcset="image.source.pc"> -->
-      <img :src="image.img" :alt="image.alt" @error="noImage">
+      <img :src="image.src" :alt="image.alt" @error="noImage">
     </picture>
   </div>
 </template>
@@ -29,7 +29,7 @@ export default {
      *     sp: 'url' {String},
      *     pc: 'url' {String},
      *   },
-     *   image: 'url' {String},
+     *   src: 'url' {String},
      *   alt: 'url' {String},
      * }
      */

--- a/src/resources/js/components/modules/UserThumbnailComponent.vue
+++ b/src/resources/js/components/modules/UserThumbnailComponent.vue
@@ -35,7 +35,7 @@ export default {
      */
     image: {
       type: Object,
-      default: {},
+      default: null,
     },
 
     /**

--- a/src/resources/js/components/modules/label/LabelComponent.vue
+++ b/src/resources/js/components/modules/label/LabelComponent.vue
@@ -2,7 +2,9 @@
   <div class="label">
     <div class="label__wrap" :class="colorModifier">
       <slot name="labelText">
-        <span class="label__text">{{ label.text }}</span>
+        <span class="label__text" :class="{'label__text-en': isAlphanumeric(label.text)}">
+          {{ label.text }}
+        </span>
       </slot>
     </div>
   </div>
@@ -25,6 +27,17 @@ export default {
     colorModifier() {
       return (this.label.color) ? `label__wrap--${this.label.color}` : null;
     },
+  },
+
+  methods: {
+    /**
+     * 半角英数字かをチェックする。
+     * @param {String} チェック対象の文字列
+     * @return {Boolean} 半角英数字ならtrue。そ以外ならfalse。
+     */
+    isAlphanumeric(str) {
+      return /^[A-Za-z0-9]*$/.test(str);
+    }
   },
 }
 
@@ -76,6 +89,10 @@ export default {
     font-size: font(10);
     letter-spacing: 1.8px;
     line-height: 2;
+
+    &-en {
+      letter-spacing: 1px;
+    }
   }
 }
 </style>

--- a/src/resources/js/components/modules/label/LabelComponent.vue
+++ b/src/resources/js/components/modules/label/LabelComponent.vue
@@ -66,6 +66,10 @@ export default {
     &--red {
       background-color: color(japanRed);
     }
+
+    &--twitter {
+      background-color: color(twitter);
+    }
   }
 
   &__text {

--- a/src/resources/js/components/modules/ticket/PlayerTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/PlayerTicketComponent.vue
@@ -1,0 +1,165 @@
+<template>
+  <user-ticket @openModal="openModal">
+    <template v-slot:thumbnail>
+      <user-thumbnail :image="thumbnail" :borderColor='positionColor'/>
+    </template>
+
+    <template v-slot:name>
+      <span class="player-ticket__name">{{ player.name_ja }}</span>
+      <span class="player-ticket__name">{{ player.name_en }}</span>
+    </template>
+
+    <template v-slot:label>
+      <div class="player-ticket__label" v-for="(label, i) in labels" :key="i">
+        <label-component :label="label"/>
+      </div>
+    </template>
+
+    <template v-slot:modal>
+      <user-modal v-if="showModal" @close="closeModal" :item="player"/>
+    </template>
+  </user-ticket>
+</template>
+
+<script>
+// component import
+import UserTicket from './UserTicketComponent';
+import UserThumbnail from '../UserThumbnailComponent';
+import LabelComponent from '../label/LabelComponent';
+import ProviderModal from '../modal/ProviderModalComponent';
+import UserModal from '../modal/UserModalComponent';
+
+export default {
+  components: {
+    UserTicket,
+    LabelComponent,
+    ProviderModal,
+    UserThumbnail,
+    UserModal,
+  },
+
+  data() {
+    return {
+      /**
+       * [モーダル表示フラグ]
+       * @type { Boolean }
+       */
+      showModal: false,
+
+      /**
+       * thumbnailコンポーネントに渡すオブジェクト
+       * @type {Object}
+       */
+      thumbnail: {
+        img: '',
+        alt: ''
+      },
+
+      /**
+       * LabelComponentに渡すデータ
+       * @type {Array}
+       */
+      labels: [],
+    }
+  },
+
+  props: {
+    player: {
+      type: Object,
+      default: null
+    }
+  },
+
+  computed: {
+    /**
+     * ポジションでサムネイルを色分けする。
+     * @return {String} css class
+     */
+    positionColor() {
+      return (this.player.position) ? this.player.position.color : 'blue';
+    },
+  },
+
+  created() {
+    const player = this.player;
+    this.thumbnail.src = player.img.src;
+    this.thumbnail.alt = player.img.alt;
+
+    // ポジションラベルのデータを作成。
+    if (player.position) {
+      this.labels.push(this.formatToLabel(player.position.color, player.position.name_ja));
+    }
+
+    /**
+     * Labelに表示するタグを絞り込み
+     * [主将, 主務, 副主将, 会計, 寮長]
+     */
+    const labelTagId = [2, 3, 4, 5, 6];
+    labelTagId.forEach(id => {
+      let tag = this.pickUpTag(id);
+      if (tag) {
+        this.labels.push(this.formatToLabel('darkblue', tag.name_ja));
+      }
+    })
+  },
+
+  methods: {
+    /**
+     * モーダル開閉処理。
+     */
+    openModal() {
+      this.showModal = true;
+      document.body.classList.add("modal-open");
+    },
+    closeModal() {
+      this.showModal = false;
+      document.body.classList.remove("modal-open");
+    },
+
+    /**
+     * ラベルコンポーネントに渡すオブジェクトを生成する。
+     * @param1 {string} tag color
+     * @param2 {string} tag text
+     * @return {Object} ラベルコンポーネントに渡すオブジェクト
+     */
+    formatToLabel(color, text) {
+      let data = {};
+      data.color = color;
+      data.text = text;
+      return data;
+    },
+
+    /**
+     * ラベルに出力するタグをIDで抽出する。
+     * @param {Number} 抽出したいタグのid
+     * @return {Object} tag object
+     */
+    pickUpTag(id) {
+      return this.player.tags.find(el => {
+        return (el.tag_id === id);
+      })
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.player-ticket {
+  &__name {
+    display: block;
+    font-size: font(14);
+
+    &:last-of-type {
+      font-size: font(12);
+    }
+  }
+
+  &__label {
+    margin: interval(.5) interval(.5) 0 0;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+</style>

--- a/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
@@ -1,11 +1,11 @@
 <template>
-  <user-ticket :user="provider">
-    <template v-slot:thumbnail="provider">
-      <user-thumbnail :image="provider.user.img"/>
+  <user-ticket @openModal="openModal">
+    <template v-slot:thumbnail>
+      <user-thumbnail :image="provider.img"/>
     </template>
 
-    <template v-slot:name="provider">
-      <span class="provider-ticket__name">{{ provider.user.name }}</span>
+    <template v-slot:name>
+      <span class="player-ticket__name">{{ provider.name }}</span>
     </template>
 
     <template v-slot:label>
@@ -15,7 +15,7 @@
     </template>
 
     <template v-slot:modal="provider">
-      <provider-modal v-if="isShow" :item="provider.user" @close="closeModal"/>
+      <provider-modal v-if="showModal" :item="provider" @close="closeModal"/>
     </template>
   </user-ticket>
 </template>
@@ -41,7 +41,7 @@ export default {
        * モーダルの開閉判定フラグ
        * @type { Boolean }
        */
-      isShow: false,
+      showModal: false,
 
       /**
        * labelData
@@ -59,16 +59,19 @@ export default {
   },
 
   created() {
-    console.log(this.provider);
     this.labels.push(this.formatToLabel('twitter', 'Twitter'));
   },
 
   methods: {
     /**
-     * [モーダル閉じる]
+     * モーダル開閉処理
      */
+    openModal() {
+      this.showModal = true;
+      document.body.classList.add("modal-open");
+    },
     closeModal() {
-      this.isShow = false;
+      this.showModal = false;
       document.body.classList.remove("modal-open");
     },
 

--- a/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/ProviderTicketComponent.vue
@@ -1,41 +1,38 @@
 <template>
-<div class="provider-ticket" ref="targetElement">
-  <div class="provider-ticket__ticket" @click="openModal">
-    <div class="provider-ticket-thumbnail-border">
-      <figure class="provider-ticket-thumbnail">
-        <img :src="provider.profile_image_url_original" :alt="`${provider.name}のプロフィール画像`">
-      </figure>
-    </div>
+  <user-ticket :user="provider">
+    <template v-slot:thumbnail="provider">
+      <user-thumbnail :image="provider.user.img"/>
+    </template>
 
-    <div class="provider-ticket-item">
-      <span class="provider-ticket__name">{{ provider.name }}</span>
+    <template v-slot:name="provider">
+      <span class="provider-ticket__name">{{ provider.user.name }}</span>
+    </template>
 
-      <!-- SNSタグは 2つ まで -->
-      <div class="provider-ticket-tag-group">
-        <sns-tag sns="twitter" content="Twitter"/>
-        <sns-tag sns="instagram" content="Instagram"/>
+    <template v-slot:label>
+      <div class="provider-ticket__label" v-for="(label, i) in labels" :key="i">
+        <label-component :label="label"/>
       </div>
-    </div>
+    </template>
 
-    <div class="provider-ticket-item">
-      <svg-vue class="provider-ticket-icon" icon="angle_right"/>
-    </div>
-  </div>
-
-  <!-- モーダル -->
-  <provider-modal v-if="isShow" :item="provider" @close="closeModal"/>
-</div>
+    <template v-slot:modal="provider">
+      <provider-modal v-if="isShow" :item="provider.user" @close="closeModal"/>
+    </template>
+  </user-ticket>
 </template>
 
 <script>
 // component import
-import SnsTag from '../tag/SnsTagComponent';
+import UserTicket from '../ticket/UserTicketComponent';
+import UserThumbnail from '../UserThumbnailComponent';
+import LabelComponent from '../label/LabelComponent';
 import ProviderModal from '../modal/ProviderModalComponent';
 
 export default {
   components: {
-    SnsTag,
+    UserTicket,
+    LabelComponent,
     ProviderModal,
+    UserThumbnail,
   },
 
   data() {
@@ -45,6 +42,12 @@ export default {
        * @type { Boolean }
        */
       isShow: false,
+
+      /**
+       * labelData
+       * @type {object}
+       */
+      labels: [],
     }
   },
 
@@ -55,17 +58,31 @@ export default {
     }
   },
 
+  created() {
+    console.log(this.provider);
+    this.labels.push(this.formatToLabel('twitter', 'Twitter'));
+  },
+
   methods: {
     /**
-     * [モーダル開閉処理]
+     * [モーダル閉じる]
      */
-    openModal() {
-      this.isShow = true;
-      document.body.classList.add("modal-open");
-    },
     closeModal() {
       this.isShow = false;
       document.body.classList.remove("modal-open");
+    },
+
+    /**
+     * ラベルコンポーネントに渡すオブジェクトを生成する。
+     * @param1 {string} tag color
+     * @param2 {string} tag text
+     * @return {Object} ラベルコンポーネントに渡すオブジェクト
+     */
+    formatToLabel(color, text) {
+      let data = {};
+      data.color = color;
+      data.text = text;
+      return data;
     },
   },
 }
@@ -73,63 +90,17 @@ export default {
 
 <style lang="scss">
 .provider-ticket {
-  width: interval(34);
-
-  @include mq(md) {
-    cursor: pointer;
-  }
-
-  &__ticket {
-    @include flex(row nowrap, space-between, center);
-    padding: interval(1);
-    box-shadow: 0 3px 5px 3px color(darkShadow);
-    border-radius: 100px;
-
-    @include mq(md) {
-      box-shadow: 0 1px 3px 1px color(darkShadow);
-      transition: all .3s ease-out;
-    }
-
-    @include hover {
-      box-shadow: 0 3px 5px 3px color(darkShadow);
-      transform: translateY(-2px);
-    }
-  }
-
-  &-thumbnail-border {
-    @include thumbnail-border();
-    width: interval(9);
-    height: interval(9);
-  }
-
-  &-thumbnail {
-    width: 100%;
-    @include trimming(aspect(square));
-
-    @include mq(sm) {
-      width: interval(10);
-    }
-
-    & > img {
-      border-radius: radius(circle);
-    }
-  }
-
   &__name {
     display: block;
     font-size: font(14);
-    padding-left: interval(.5);
   }
 
-  &-tag-group {
-    @include flex(row wrap, flex-start, center);
-  }
+  &__label {
+    margin: interval(.5) interval(.5) 0 0;
 
-  &-icon {
-    width: interval(1.5);
-    height: interval(1.5);
-    fill: color(darkblue);
+    &:last-child {
+      margin-right: 0;
+    }
   }
 }
-
 </style>

--- a/src/resources/js/components/modules/ticket/StaffTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/StaffTicketComponent.vue
@@ -1,0 +1,150 @@
+<template>
+  <user-ticket @openModal="openModal">
+    <template v-slot:thumbnail>
+      <user-thumbnail :image="thumbnail"/>
+    </template>
+
+    <template v-slot:name>
+      <span class="staff-ticket__name">{{ staff.name_ja }}</span>
+      <span class="staff-ticket__name">{{ staff.name_en }}</span>
+    </template>
+
+    <template v-slot:label>
+      <div class="staff-ticket__label" v-for="(label, i) in labels" :key="i">
+        <label-component :label="label"/>
+      </div>
+    </template>
+
+    <template v-slot:modal>
+      <user-modal v-if="showModal" @close="closeModal" :item="staff"/>
+    </template>
+  </user-ticket>
+</template>
+
+<script>
+// component import
+import UserTicket from './UserTicketComponent';
+import UserThumbnail from '../UserThumbnailComponent';
+import LabelComponent from '../label/LabelComponent';
+import ProviderModal from '../modal/ProviderModalComponent';
+import UserModal from '../modal/UserModalComponent';
+
+export default {
+  components: {
+    UserTicket,
+    LabelComponent,
+    ProviderModal,
+    UserThumbnail,
+    UserModal,
+  },
+
+  data() {
+    return {
+      /**
+       * [モーダル表示フラグ]
+       * @type { Boolean }
+       */
+      showModal: false,
+
+      /**
+       * thumbnailコンポーネントに渡すオブジェクト
+       * @type {Object}
+       */
+      thumbnail: {
+        img: '',
+        alt: ''
+      },
+
+      /**
+       * LabelComponentに渡すデータ
+       * @type {Array}
+       */
+      labels: [],
+    }
+  },
+
+  props: {
+    staff: {
+      type: Object,
+      default: null
+    }
+  },
+
+  created() {
+    const staff = this.staff;
+    this.thumbnail.src = staff.img.src;
+    this.thumbnail.alt = staff.img.alt;
+
+    /**
+     * Labelに表示するタグを絞り込み
+     * [監督, 部長, コーチ]
+     */
+    const labelTagId = [8, 9, 10];
+    labelTagId.forEach(id => {
+      let tag = this.pickUpTag(id);
+      if (tag) {
+        this.labels.push(this.formatToLabel('darkblue', tag.name_ja));
+      }
+    })
+  },
+
+  methods: {
+    /**
+     * モーダル開閉処理。
+     */
+    openModal() {
+      this.showModal = true;
+      document.body.classList.add("modal-open");
+    },
+    closeModal() {
+      this.showModal = false;
+      document.body.classList.remove("modal-open");
+    },
+
+    /**
+     * ラベルコンポーネントに渡すオブジェクトを生成する。
+     * @param1 {string} tag color
+     * @param2 {string} tag text
+     * @return {Object} ラベルコンポーネントに渡すオブジェクト
+     */
+    formatToLabel(color, text) {
+      let data = {};
+      data.color = color;
+      data.text = text;
+      return data;
+    },
+
+    /**
+     * ラベルに出力するタグをIDで抽出する。
+     * @param {Number} 抽出したいタグのid
+     * @return {Object} tag object
+     */
+    pickUpTag(id) {
+      return this.staff.tags.find(el => {
+        return (el.tag_id === id);
+      })
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.staff-ticket {
+  &__name {
+    display: block;
+    font-size: font(14);
+
+    &:last-of-type {
+      font-size: font(12);
+    }
+  }
+
+  &__label {
+    margin: interval(.5) interval(.5) 0 0;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+</style>

--- a/src/resources/js/components/modules/ticket/UserTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/UserTicketComponent.vue
@@ -1,20 +1,25 @@
 <template>
   <div class="user-ticket">
-    <!-- 子コンポーネントにあるモーダルフラグをいじる -->
     <div class="user-ticket__ticket" @click="$emit('openModal')">
       <div class="user-ticket__thumbnail">
+        <!-- サムネイル：userThumbnailComponentを想定 -->
         <slot name="thumbnail"/>
       </div>
 
       <div class="user-ticket__profile">
-        <slot name="name"/>
+        <div class="user-ticket__name-wrap">
+          <!-- 名前 -->
+          <slot name="name"/>
+        </div>
 
         <div class="user-ticket__label-group">
+          <!-- ラベル：LabelComponentを想定 -->
           <slot name="label"/>
         </div>
       </div>
     </div>
 
+    <!-- モーダル -->
     <slot name="modal"/>
   </div>
 </template>

--- a/src/resources/js/components/modules/ticket/UserTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/UserTicketComponent.vue
@@ -1,159 +1,23 @@
 <template>
-<div class="user-ticket">
-  <div class="user-ticket__ticket" @click="openModal">
-    <div class="user-ticket__thumbnail">
-      <slot name="thumbnail" :user="user">
-        <user-thumbnail :image="thumbnail" :borderColor='positionColor'/>
-      </slot>
-    </div>
+  <div class="user-ticket">
+    <!-- 子コンポーネントにあるモーダルフラグをいじる -->
+    <div class="user-ticket__ticket" @click="$emit('openModal')">
+      <div class="user-ticket__thumbnail">
+        <slot name="thumbnail"/>
+      </div>
 
-    <div class="user-ticket__profile">
-      <slot name="name" :user="user">
-        <span class="user-ticket__profile-name">{{ user.name_ja }}</span>
-        <span class="user-ticket__profile-name">{{ user.name_en }}</span>
-      </slot>
+      <div class="user-ticket__profile">
+        <slot name="name"/>
 
-      <div class="user-ticket__label-group">
-        <slot name="label" :user="user">
-          <div class="user-ticket__label" v-for="(label, i) in labels" :key="i">
-            <label-component :label="label"/>
-          </div>
-        </slot>
+        <div class="user-ticket__label-group">
+          <slot name="label"/>
+        </div>
       </div>
     </div>
+
+    <slot name="modal"/>
   </div>
-
-  <slot name="modal" :user="user">
-    <user-modal v-if="showModal" @close="closeModal" :item="user"/>
-  </slot>
-</div>
 </template>
-
-<script>
-// component import
-import UserModal from '../modal/UserModalComponent';
-import UserThumbnail from '../UserThumbnailComponent';
-import LabelComponent from '../label/LabelComponent';
-
-export default {
-  components: {
-    UserModal,
-    LabelComponent,
-    UserThumbnail,
-  },
-
-  data() {
-    return {
-      /**
-       * [モーダル表示フラグ]
-       * @type { Boolean }
-       */
-      showModal: false,
-
-      /**
-       * thumbnailコンポーネントに渡すオブジェクト
-       * @type {Object}
-       */
-      thumbnail: {
-        img: '',
-        alt: ''
-      },
-
-      /**
-       * LabelComponentに渡すデータ
-       * @type {Array}
-       */
-      labels: [],
-    }
-  },
-
-  props: {
-    user: {
-      type: Object,
-      default: null
-    }
-  },
-
-  computed: {
-    /**
-     * playerのみサムネイルを色分けする。
-     * @return {String} css class
-     */
-    positionColor() {
-      return (this.user.position && this.userType(1)) ? this.user.position.color : 'blue';
-    },
-  },
-
-  created() {
-    const user = this.user;
-    this.thumbnail.src = user.img.src;
-    this.thumbnail.alt = user.img.alt;
-
-    // playerのみポジションラベルをつける。
-    if (user.position && this.userType(1)) {
-      this.labels.push(this.formatToLabel(user.position.color, user.position.name_ja));
-    }
-
-    // Labelに表示するタグを絞り込み
-    const labelTagId = [2, 3, 4, 5, 6, 8, 9, 10];
-    labelTagId.forEach(id => {
-      let tag = this.pickUpTag(id);
-      if (tag) {
-        this.labels.push(this.formatToLabel('darkblue', tag.name_ja));
-      }
-    })
-  },
-
-  methods: {
-    /**
-     * [モーダル開閉処理]
-     */
-    openModal() {
-      this.showModal = true;
-      document.body.classList.add("modal-open");
-    },
-    closeModal() {
-      this.showModal = false;
-      document.body.classList.remove("modal-open");
-    },
-
-    /**
-     * ラベルコンポーネントに渡すオブジェクトを生成する。
-     * @param1 {string} tag color
-     * @param2 {string} tag text
-     * @return {Object} ラベルコンポーネントに渡すオブジェクト
-     */
-    formatToLabel(color, text) {
-      let data = {};
-      data.color = color;
-      data.text = text;
-      return data;
-    },
-
-    /**
-     * ラベルに出力するタグをIDで抽出する。
-     * @param {Number} 抽出したいタグのid
-     * @return {Object} tag object
-     */
-    pickUpTag(id) {
-      return this.user.tags.find(el => {
-        return (el.tag_id === id);
-      })
-    },
-
-    /**
-     * ユーザータイプをタグで判定する。
-     * [1]:部員
-     * [7]:スタッフ
-     * @param {Number} tag_id
-     * @return {Boolean}
-     */
-    userType(id) {
-      return this.user.tags.some(tag => tag.tag_id === id);
-    }
-  },
-}
-</script>
 
 <style lang="scss">
 .user-ticket {
@@ -187,23 +51,11 @@ export default {
     &-name {
       display: block;
       font-size: font(14);
-
-      &:last-of-type {
-        font-size: font(12);
-      }
     }
   }
 
   &__label-group {
     @include flex(row wrap, flex-start, center);
-  }
-
-  &__label {
-    margin: interval(.5) interval(.5) 0 0;
-
-    &:last-child {
-      margin-right: 0;
-    }
   }
 }
 

--- a/src/resources/js/components/modules/ticket/UserTicketComponent.vue
+++ b/src/resources/js/components/modules/ticket/UserTicketComponent.vue
@@ -2,22 +2,30 @@
 <div class="user-ticket">
   <div class="user-ticket__ticket" @click="openModal">
     <div class="user-ticket__thumbnail">
-      <user-thumbnail :image="thumbnail" :borderColor='positionColor'/>
+      <slot name="thumbnail" :user="user">
+        <user-thumbnail :image="thumbnail" :borderColor='positionColor'/>
+      </slot>
     </div>
 
     <div class="user-ticket__profile">
-      <span class="user-ticket__profile-name">{{ user.name_ja }}</span>
-      <span class="user-ticket__profile-name">{{ user.name_en }}</span>
+      <slot name="name" :user="user">
+        <span class="user-ticket__profile-name">{{ user.name_ja }}</span>
+        <span class="user-ticket__profile-name">{{ user.name_en }}</span>
+      </slot>
 
       <div class="user-ticket__label-group">
-        <div class="user-ticket__label" v-for="(label, i) in labels" :key="i">
-          <label-component :label="label"/>
-        </div>
+        <slot name="label" :user="user">
+          <div class="user-ticket__label" v-for="(label, i) in labels" :key="i">
+            <label-component :label="label"/>
+          </div>
+        </slot>
       </div>
     </div>
   </div>
 
-  <user-modal v-if="showModal" @close="closeModal" :item="user"/>
+  <slot name="modal" :user="user">
+    <user-modal v-if="showModal" @close="closeModal" :item="user"/>
+  </slot>
 </div>
 </template>
 
@@ -78,7 +86,7 @@ export default {
 
   created() {
     const user = this.user;
-    this.thumbnail.img = user.img.src;
+    this.thumbnail.src = user.img.src;
     this.thumbnail.alt = user.img.alt;
 
     // playerのみポジションラベルをつける。

--- a/src/resources/js/views/Member.vue
+++ b/src/resources/js/views/Member.vue
@@ -29,7 +29,7 @@
       @after-enter="cancelDelay">
 
       <div class="member__ticket" v-for="(player, i) in user.players" :key="player.id" :data-index="i">
-        <user-ticket :user="player"/>
+        <player-ticket :player="player"/>
       </div>
     </transition-group>
   </section>
@@ -44,7 +44,7 @@
       @after-enter="cancelDelay">
 
       <div class="member__ticket" v-for="(staff, i) in user.staff" :key="staff.id" :data-index="i">
-        <user-ticket :user="staff"/>
+        <staff-ticket :staff="staff"/>
       </div>
     </transition-group>
   </section>
@@ -61,7 +61,8 @@
 import MainVisual from '../components/contents/MainVisualComponent';
 import ScrollTopButton from '../components/modules/button/ScrollTopButtonComponent';
 import ContentsTitle from '../components/modules/ContentsTitleComponent';
-import UserTicket from '../components/modules/ticket/UserTicketComponent';
+import PlayerTicket from '../components/modules/ticket/PlayerTicketComponent';
+import StaffTicket from '../components/modules/ticket/StaffTicketComponent';
 
 // config
 import Api from '../config/api/index';
@@ -71,7 +72,8 @@ export default {
   components: {
     MainVisual,
     ContentsTitle,
-    UserTicket,
+    PlayerTicket,
+    StaffTicket,
     ScrollTopButton,
   },
 


### PR DESCRIPTION
## 概要
### プロバイダーチケットのレイアウトを修正。
プロバイダーチケットのレイアウトをメンバーページのチケットに合わせる。

### UserTicketComponentを細分化
UserTicket
    ┗ PlayerTicketComponent
    ┗ StaffTicketComponent
    ┗ providerTicketComponent
slotを使ってチケットのフレームコンポーネントを作成。

### ツイッターAPIの写真データ構造をUserThumbnailComponentに合わせて修正
コンポーネントを複雑にしないためにデータをコントローラーで作成。